### PR TITLE
Fix for unit tests broken by addition of play-lang library

### DIFF
--- a/test/iht/testhelpers/MessagesTidier.scala
+++ b/test/iht/testhelpers/MessagesTidier.scala
@@ -62,7 +62,7 @@ trait MessagesTidier {
   )
 
   def readmessagesApi(): Map[String, String] = {
-    val aa: Map[String, String] = getOrException(messages.get("default"))
+    val aa: Map[String, String] = getOrException(messages.get("en"))
     aa.filter(xx => !exclusions.contains(xx._1))
   }
 

--- a/test/iht/testhelpers/MessagesTidierTest.scala
+++ b/test/iht/testhelpers/MessagesTidierTest.scala
@@ -28,7 +28,7 @@ class MessagesTidierTest extends UnitSpec with FakeIhtApp {
 
   val runTestsThatUseFileSystem = false
   val runTestsThatSortErrorMessages = false
-  val runTestsThatSortIhtMessages = false
+  val runTestsThatSortIhtMessages = true
   val runTestsThatReplaceMessageKeys = false
   val runTestsThatGenerateAllErrorMessageKeysForReplace = false
 
@@ -693,7 +693,7 @@ class MessagesTidierTest extends UnitSpec with FakeIhtApp {
           val sortedErrorMessages = MessagesTidier.sortErrormessagesApi(messagesAsTuples)
           mockedMessagesTidier.writeToFile("/home/grant/Desktop/waa1.txt", sortedErrorMessages)
 
-          val inputFilePath = getResourceAsFilePath("messages")
+          val inputFilePath = getResourceAsFilePath("messages.en")
 
           val result1: Seq[(String, String)] = MessagesTidier.getNonErrorMessagesExclCommentedKeys(inputFilePath)
           mockedMessagesTidier.writeToFile("/home/grant/Desktop/waa2.txt", result1)

--- a/test/iht/testhelpers/MessagesTidierTest.scala
+++ b/test/iht/testhelpers/MessagesTidierTest.scala
@@ -73,7 +73,7 @@ class MessagesTidierTest extends UnitSpec with FakeIhtApp {
   val mockedMessagesWithoutDuplicateKeysAsMapOfSets = Map("aaa" -> Set("bbb"), "ccc" -> Set("ddd"))
 
   val mockedMessagesTidier = new MessagesTidier {
-    override val messages: Map[String, Map[String, String]] = Map("default" -> mockedMessagesWithDuplicateValuesAsMap)
+    override val messages: Map[String, Map[String, String]] = Map("en" -> mockedMessagesWithDuplicateValuesAsMap)
   }
 
   def getResourceAsFilePath(filePath: String) = {

--- a/test/iht/testhelpers/MessagesTidierTest.scala
+++ b/test/iht/testhelpers/MessagesTidierTest.scala
@@ -28,7 +28,7 @@ class MessagesTidierTest extends UnitSpec with FakeIhtApp {
 
   val runTestsThatUseFileSystem = false
   val runTestsThatSortErrorMessages = false
-  val runTestsThatSortIhtMessages = true
+  val runTestsThatSortIhtMessages = false
   val runTestsThatReplaceMessageKeys = false
   val runTestsThatGenerateAllErrorMessageKeysForReplace = false
 

--- a/test/iht/testhelpers/MessagesTidierTest.scala
+++ b/test/iht/testhelpers/MessagesTidierTest.scala
@@ -671,7 +671,7 @@ class MessagesTidierTest extends UnitSpec with FakeIhtApp {
           val sortedErrorMessages = MessagesTidier.sortErrormessagesApi(messagesAsTuples)
           mockedMessagesTidier.writeToFile("/home/grant/Desktop/waa1.txt", sortedErrorMessages)
 
-          val inputFilePath = getResourceAsFilePath("messages")
+          val inputFilePath = getResourceAsFilePath("messages.en")
 
           val result1: Seq[(String, String)] = MessagesTidier.getNonErrorMessagesExclCommentedKeys(inputFilePath)
           mockedMessagesTidier.writeToFile("/home/grant/Desktop/waa2.txt", result1)


### PR DESCRIPTION
Just noticed that the unit test which looks for duplicated content was no longer working due to the addition of play-lang. This is to fix it.