### PR TITLE
Updating error message styling to current recommended latest style

### DIFF
--- a/app/assets/stylesheets/iht-app.scss
+++ b/app/assets/stylesheets/iht-app.scss
@@ -2,6 +2,7 @@
 @import 'partials/_base';
 
 @import 'partials/_forms';
+@import 'partials/_form-validation';
 @import 'partials/_buttons';
 @import 'partials/_tables';
 @import 'partials/_grid';

--- a/app/assets/stylesheets/partials/_form-validation.scss
+++ b/app/assets/stylesheets/partials/_form-validation.scss
@@ -1,0 +1,110 @@
+// Form validation
+// ==========================================================================
+$error-colour: #b10e1e;
+$focus-colour: #ffbf47;
+
+$gutter: 30px;
+$gutter-one-sixth: $gutter / 6;
+$gutter-one-third: $gutter / 3;
+$gutter-half: $gutter / 2;
+$gutter-two-thirds: $gutter - $gutter-one-third;
+
+
+// Use .form-group-error to add a red border to the left of a .form-group
+.form-group-error {
+  margin-right: $gutter-half;
+  border-left: 4px solid $error-colour;
+  padding-left: $gutter-one-third;
+}
+
+@media (min-width: 641px) {
+  .form-group-error {
+    border-left: $gutter-one-sixth solid $error-colour;
+    padding-left: $gutter-half;
+  }
+}
+
+
+// Use .form-control-error to add a red border to .form-control
+.form-control-error {
+  border: 4px solid $error-colour;
+}
+
+
+// Error messages should be red and bold
+.error-message {
+  font-weight: 700;
+  font-size: 16px;
+  color: $error-colour;
+
+
+  display: block;
+  clear: both;
+
+  margin: 0;
+  padding: 2px 0;
+}
+
+@media (min-width: 641px) {
+  .error-message {
+    font-size: 19px;
+  }
+}
+
+.form-label .error-message,
+.form-label-bold .error-message {
+  padding-top: 4px;
+  padding-bottom: 0;
+}
+
+// Summary of multiple error messages
+.error-summary {
+
+  // Error summary has a border on all sides
+  border: 4px solid $error-colour;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  padding: $gutter-half $gutter-one-third;
+
+  // Use the GOV.UK outline focus style
+  &:focus {
+    outline: 3px solid $focus-colour;
+  }
+
+  .error-summary-heading {
+    margin-top: 0;
+  }
+
+  p {
+    margin-bottom: $gutter-one-third;
+  }
+
+  .error-summary-list {
+    padding-left: 0;
+
+    @media (min-width: 641px) {
+      li {
+        margin-bottom: 5px;
+      }
+    }
+
+    a {
+      color: $error-colour;
+      font-weight: bold;
+      text-decoration: underline;
+    }
+  }
+}
+
+@media (min-width: 641px) {
+  .error-summary {
+    border: $gutter-one-sixth solid $error-colour;
+
+    margin-top: $gutter;
+    margin-bottom: $gutter;
+
+    padding: $gutter-two-thirds $gutter-half $gutter-half;
+  }
+}

--- a/app/iht/views/application/asset/properties/property_address.scala.html
+++ b/app/iht/views/application/asset/properties/property_address.scala.html
@@ -42,7 +42,7 @@ headingClass = "heading-large"
     @ihtHelpers.standard.input_with_help(propertyAddressForm("address.ukAddressLine1"),
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_inputClass -> "form-control js-nonNumeric",
-    '_labelTextClass -> "form-label",
+    '_labelTextClass -> "bold",
     '_label -> Html(Messages("iht.address.line1"))
     )
 </div>
@@ -50,7 +50,7 @@ headingClass = "heading-large"
     @ihtHelpers.standard.input_with_help(propertyAddressForm("address.ukAddressLine2"),
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_inputClass -> "form-control js-nonNumeric",
-    '_labelTextClass -> "form-label",
+    '_labelTextClass -> "bold",
     '_label -> Html(Messages("iht.address.line2"))
     )
 </div>
@@ -58,7 +58,7 @@ headingClass = "heading-large"
     @ihtHelpers.standard.input_with_help(propertyAddressForm("address.ukAddressLine3"),
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_inputClass -> "form-control js-nonNumeric",
-    '_labelTextClass -> "form-label",
+    '_labelTextClass -> "bold",
     '_label -> Html(Messages("iht.address.line3"))
     )
 </div>
@@ -66,7 +66,7 @@ headingClass = "heading-large"
     @ihtHelpers.standard.input_with_help(propertyAddressForm("address.ukAddressLine4"),
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_inputClass -> "form-control js-nonNumeric",
-    '_labelTextClass -> "form-label",
+    '_labelTextClass -> "bold",
     '_label -> Html(Messages("iht.address.line4"))
     )
 </div>
@@ -75,7 +75,7 @@ headingClass = "heading-large"
     '_maxlength -> IhtProperties.validationMaxLengthPostcode,
     '_divClass -> "",
     '_inputClass -> "form-control form-control-1-4 js-nonNumeric",
-    '_labelTextClass -> "form-label ",
+    '_labelTextClass -> "bold ",
     '_label -> Html(Messages("iht.postcode"))
     )
 </div>

--- a/app/iht/views/application/tnrb/partner_name.scala.html
+++ b/app/iht/views/application/tnrb/partner_name.scala.html
@@ -46,7 +46,7 @@ cancelUrl = Some(cancelUrl)){
         '_maxlength -> IhtProperties.validationMaxLengthFirstName,
         '_divClass -> "form-group ",
         '_inputClass -> "form-control",
-        '_labelTextClass -> "form-label",
+        '_labelTextClass -> "bold",
         '_label -> Html(Messages("iht.firstName")),
         '_hintText -> Messages("iht.firstName.hint")
     )
@@ -55,7 +55,7 @@ cancelUrl = Some(cancelUrl)){
         '_maxlength -> IhtProperties.validationMaxLengthLastName,
         '_divClass -> "form-group ",
         '_inputClass -> "form-control",
-        '_labelTextClass -> "form-label",
+        '_labelTextClass -> "bold",
         '_label -> Html(Messages("iht.lastName"))
         )
         <div id="action-button" class="form-field form-field--submit">

--- a/app/iht/views/ihtHelpers/custom/error_summary.scala.html
+++ b/app/iht/views/ihtHelpers/custom/error_summary.scala.html
@@ -28,14 +28,14 @@
 *@
 
 @if(form.hasErrors) {
-<div id="errors" tabindex="-1" role="alert" class="validation-summary" aria-labelledby="errors-heading">
-    <h2 class="heading-small" id="errors-heading">@Messages("error.problem")</h2>
+<div id="errors" tabindex="-1" role="alert" class="error-summary error-summary--show" aria-labelledby="errors-heading">
+    <h2 class="heading-medium error-summary-heading" id="errors-heading">@Messages("error.problem")</h2>
     <p>@Messages("error.checkCorrect")</p>
-    <ul class="error-list">
+    <ul class="error-summary-list">
         @form.errors.map { error =>
         @defining(messages(s"${error.message}.summary", error.args : _*)) { errMsg =>
         @if(!errMsg.equals(".summary")) {
-                <li class="validation-message" id='@error.key.replaceAll("""[\.\[\]]""", "_")Error'>
+                <li id='@error.key.replaceAll("""[\.\[\]]""", "_")Error'>
                     <a href='#@error.key.replaceAll("""[\[\]]""", "_")-container'>
                         @overrideSummaryMessages(overrideKeys, error)
                     </a>

--- a/app/iht/views/ihtHelpers/custom/questionnaire_form.scala.html
+++ b/app/iht/views/ihtHelpers/custom/questionnaire_form.scala.html
@@ -29,7 +29,7 @@
         '_fieldsetId -> "feeling-about-experience",
         '_groupClass -> "form-group ",
         '_labelClass -> "block-label",
-        '_labelTextClass -> "form-label",
+        '_labelTextClass -> "bold",
         '_legendClass -> "form-label-bold"
     )
 
@@ -40,7 +40,7 @@
         '_fieldsetId -> "easy-to-use",
         '_groupClass -> "form-group ",
         '_labelClass -> "block-label",
-        '_labelTextClass -> "form-label",
+        '_labelTextClass -> "bold",
         '_legendClass -> "form-label-bold"
     )
 
@@ -52,7 +52,7 @@
         '_fieldsetId -> "stageInService",
         '_groupClass -> "form-group ",
         '_labelClass -> "block-label",
-        '_labelTextClass -> "form-label",
+        '_labelTextClass -> "bold",
         '_legendClass -> "form-label-bold"
     )
 

--- a/app/iht/views/ihtHelpers/standard/date_fields.scala.html
+++ b/app/iht/views/ihtHelpers/standard/date_fields.scala.html
@@ -56,15 +56,17 @@
         @elements.args.get('_extraText)
     </div>
     }
+
+<div id="@{elements.field.name}-container" class="form-group form-date @elements.args.get('_groupClass) @if(elements.hasErrors) {form-group-error}">
+
     @if(elements.args.get('_hintText).isDefined) {
-    <div class="form-hint@if(elements.args.get('_hintClass).isDefined) { @elements.args.get('_hintClass)}" @if(elements.args.contains('_hintId)){id="@elements.args.get('_hintId)"}>
-        @elements.args.get('_hintText)
-    </div>
+        <div class="form-hint@if(elements.args.get('_hintClass).isDefined) { @elements.args.get('_hintClass)}" @if(elements.args.contains('_hintId)){id="@elements.args.get('_hintId)"}>
+            @elements.args.get('_hintText)
+        </div>
     }
-<div id="@{elements.field.name}-container" class="form-field @elements.args.get('_groupClass) @if(elements.hasErrors) {form-field--error}">
 
     @defining(elements.field.name){fieldName=>
-        @elements.errors.map{error => <span class="error-notification" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
+        @elements.errors.map{error => <span class="error-message" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
     }
 
 

--- a/app/iht/views/ihtHelpers/standard/date_input.scala.html
+++ b/app/iht/views/ihtHelpers/standard/date_input.scala.html
@@ -38,12 +38,12 @@
 
     <label for="@elements.field.name" class="
         @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) }
-        @if(elements.hasErrors || (parentElements.isDefined && CommonHelper.getOrException(parentElements).hasErrors)) {form-field--error}"
+        @if(elements.hasErrors || (parentElements.isDefined && CommonHelper.getOrException(parentElements).hasErrors)) {form-group-error}"
     @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}
     >
 
     @defining(elements.field.name){fieldName=>
-        @elements.errors.map{error => <span class="error-notification" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
+        @elements.errors.map{error => <span class="error-message" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
     }
 
     @if(parentElements.isDefined) {

--- a/app/iht/views/ihtHelpers/standard/dropdown.scala.html
+++ b/app/iht/views/ihtHelpers/standard/dropdown.scala.html
@@ -28,17 +28,17 @@
 @labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
 @labelHighlight = @{ elements.args.get('_labelHighlight).getOrElse(false).asInstanceOf[Boolean] }
 
-<div data-exclude="true" class="form-group @if(elements.hasErrors || (parentElements.isDefined && CommonHelper.getOrException(parentElements).hasErrors)) {form-field--error}">
+<div data-exclude="true" class="form-group @if(elements.hasErrors || (parentElements.isDefined && CommonHelper.getOrException(parentElements).hasErrors)) {form-group-error}">
 
 
     <label for="@if( elements.args.get('_id) ) {@elements.args.get('_id)} else {@elements.field.name.replaceAll("""[\.\[\]]""", "-")}" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) }" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)} id="@if( elements.args.get('_labelid) ) {@elements.args.get('_labelid)} else {@elements.field.name.replaceAll("""[\.\[\]]""", "-")_field}">
         @if(labelHighlight){<strong>}
-        @if(elements.args.contains('_label)) {<span class="form-label @if(elements.args.contains('_labelClass)){ @elements.args.get('_labelClass)}"> @elements.label </span>}
+        @if(elements.args.contains('_label)) {<span class="bold @if(elements.args.contains('_labelClass)){ @elements.args.get('_labelClass)}"> @elements.label </span>}
         @if(labelHighlight){</strong>}
     </label>
 
     @defining(elements.field.name){fieldName=>
-        @elements.errors.map{error => <span class="error-notification" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
+        @elements.errors.map{error => <span class="error-message" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
     }
     @if(parentElements.isDefined) {
     @CommonHelper.getOrException(parentElements).errors.map { error => <span class="error-notification">@messages(error)</span>}

--- a/app/iht/views/ihtHelpers/standard/input_radio_group.scala.html
+++ b/app/iht/views/ihtHelpers/standard/input_radio_group.scala.html
@@ -56,11 +56,11 @@
 }
 
 @if(elements.hasErrors){
-    <div class="form-field form-field--error">
+    <div class="form-group form-group-error">
 }
 
 @defining(elements.field.name){fieldName=>
-    @elements.errors.map{error => <span class="error-notification" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
+    @elements.errors.map{error => <span class="error-message" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
 }
 
 @radioOptions.map { case (value, label) =>

--- a/app/iht/views/ihtHelpers/standard/input_radio_group_with_hints.scala.html
+++ b/app/iht/views/ihtHelpers/standard/input_radio_group_with_hints.scala.html
@@ -51,10 +51,10 @@
 }
 
 @if(elements.hasErrors) {
-    <div class="form-field form-field--error">
+    <div class="form-group form-group-error">
 }
 @defining(elements.field.name){fieldName=>
-    @elements.errors.map{error => <span class="error-notification" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
+    @elements.errors.map{error => <span class="error-message" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
 }
 @radioOptions.map { case (value, (label, hint, aria)) =>
     @defining(s"${elements.field.name}-${value.toLowerCase.replace(" ","_")}")  { inputId =>

--- a/app/iht/views/ihtHelpers/standard/input_with_help.scala.html
+++ b/app/iht/views/ihtHelpers/standard/input_with_help.scala.html
@@ -85,7 +85,7 @@
 
     @if(parentElements.isDefined) {
         @defining(elements.field.name){fieldName=>
-            @CommonHelper.getOrException(parentElements).errors.map {error => <span class="error-notification" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
+            @CommonHelper.getOrException(parentElements).errors.map {error => <span class="error-message" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
         }
     }
 
@@ -94,6 +94,9 @@
         @elements.args.get('_extraText)
     </div>
     }
+
+
+    <div class="@if(hasErrors){ form-group-error}">
 
     @if(elements.args.contains('_hintText) && !elements.args.contains('_slideOutText)) {
         <div id="@hintID" class="form-hint@if(elements.args.get('_hintClass).isDefined) { @elements.args.get('_hintClass)}">@elements.args.get('_hintText)</div>
@@ -105,12 +108,8 @@
         '_needHighlight -> true)
     }
 
-
-    <div class="form-field @if(hasErrors){ form-field--error}">
-
-
     @defining(elements.field.name){fieldName=>
-        @elements.errors.map{error => <span class="error-notification" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
+        @elements.errors.map{error => <span class="error-message" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
     }
 
     @elements.args.get('_currency) match {

--- a/app/iht/views/ihtHelpers/standard/input_yes_no_radio_group.scala.html
+++ b/app/iht/views/ihtHelpers/standard/input_yes_no_radio_group.scala.html
@@ -51,6 +51,10 @@
 </div>
 }
 
+@if(elements.hasErrors) {
+    <div class="form-group form-group-error">
+}
+
 @if(elements.args.get('_hintText).isDefined && !elements.args.contains('_slideOutText)) {
     <div class="form-hint@if(elements.args.get('_hintClass).isDefined) { @elements.args.get('_hintClass)}" @if(hintID>""){id="@hintID"}>
     @elements.args.get('_hintText)
@@ -67,12 +71,9 @@
     '_slideOutText -> elements.args.get('_slideOutText),
     '_needHighlight -> true)
 }
-@if(elements.hasErrors) {
-    <div class="form-field form-field--error">
-}
 
 @defining(elements.field.name){fieldName=>
-    @elements.errors.map{error => <span class="error-notification" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
+    @elements.errors.map{error => <span class="error-message" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
 }
 
 @import java.lang.String; val labelYes=Messages("iht.yes")

--- a/app/iht/views/ihtHelpers/standard/single_input_checkbox.scala.html
+++ b/app/iht/views/ihtHelpers/standard/single_input_checkbox.scala.html
@@ -22,10 +22,10 @@
 @value = @{ field.value match { case Some(x) => x case None => "false" case x => x }}
 
 
-<div class="form-field-single @if(elements.hasErrors) {form-field--error} @if(elements.args.get('_divClass).isDefined) {@elements.args.get('_divClass)}">
+<div class="form-field-single @if(elements.hasErrors) {form-group-error} @if(elements.args.get('_divClass).isDefined) {@elements.args.get('_divClass)}">
 
   @defining(elements.field.name){fieldName=>
-    @elements.errors.map{error => <span class="error-notification" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
+    @elements.errors.map{error => <span class="error-message" data-journey="error - field:user-input:@fieldName">@Messages(error)</span>}
   }
 
   <label class="form-checkbox block-label" for="@elements.id">

--- a/app/iht/views/registration/applicant/applicant_address.scala.html
+++ b/app/iht/views/registration/applicant/applicant_address.scala.html
@@ -45,27 +45,27 @@
           @ihtHelpers.standard.input_with_help(form("ukAddressLine1"),
             '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
             '_inputClass -> "form-control ",
-            '_labelTextClass -> "form-label",
+            '_labelTextClass -> "bold",
             '_label -> Html(Messages("iht.address.line1")))
             </div>
         <div id="ukAddress_ukAddressLine2-container" class="form-group">
           @ihtHelpers.standard.input_with_help(form("ukAddressLine2"),
             '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
             '_inputClass -> "form-control ",
-            '_labelTextClass -> "form-label",
+            '_labelTextClass -> "bold",
             '_label -> Html(Messages("iht.address.line2")))
         </div>
         <div id="ukAddress_ukAddressLine3-container" class="form-group">
           @ihtHelpers.standard.input_with_help(form("ukAddressLine3"),
             '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
             '_inputClass -> "form-control ",
-            '_labelTextClass -> "form-label",
+            '_labelTextClass -> "bold",
             '_label -> Html(Messages("iht.address.line3")))
         </div>
         <div id="ukAddress_ukAddressLine4-container" class="form-group">
           @ihtHelpers.standard.input_with_help(form("ukAddressLine4"),
             '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
-            '_inputClass -> "form-control ", '_labelTextClass -> "form-label",
+            '_inputClass -> "form-control ", '_labelTextClass -> "bold",
             '_label -> Html(Messages("iht.address.line4")))
         </div>
 
@@ -81,7 +81,7 @@
                 '_labelid -> "countryCode-container",
                 '_emptyValueText -> " ",
                 '_emptyValue -> "GB",
-                '_labelClass -> "form-label",
+                '_labelClass -> "bold",
                 '_label -> Html(messages("iht.country"))
                 )(messages)
             </div>
@@ -95,7 +95,7 @@
                 '_maxlength -> IhtProperties.validationMaxLengthPostcode,
                 '_divClass -> "form-group",
                 '_inputClass -> "form-control form-control-1-4",
-                '_labelTextClass -> "form-label",
+                '_labelTextClass -> "bold",
                 '_label -> Html(Messages("iht.postcode")))
             </div>
 

--- a/app/iht/views/registration/deceased/deceased_address_details_outside_uk.scala.html
+++ b/app/iht/views/registration/deceased/deceased_address_details_outside_uk.scala.html
@@ -48,7 +48,7 @@
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_divClass -> "form-group ",
     '_inputClass -> "form-control",
-    '_labelTextClass -> "form-label ",
+    '_labelTextClass -> "bold ",
     '_label -> Html(Messages("iht.address.line1")))
 
     @ihtHelpers.standard.input_with_help(
@@ -56,7 +56,7 @@
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_divClass -> "form-group ",
     '_inputClass -> "form-control",
-    '_labelTextClass -> "form-label ",
+    '_labelTextClass -> "bold ",
     '_label -> Html(Messages("iht.address.line2")))
 
     @ihtHelpers.standard.input_with_help(
@@ -64,7 +64,7 @@
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_divClass -> "form-group ",
     '_inputClass -> "form-control",
-    '_labelTextClass -> "form-label ",
+    '_labelTextClass -> "bold ",
     '_label -> Html(Messages("iht.address.line3")))
 
     @ihtHelpers.standard.input_with_help(
@@ -72,7 +72,7 @@
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_divClass -> "form-group ",
     '_inputClass -> "form-control",
-    '_labelTextClass -> "form-label",
+    '_labelTextClass -> "bold",
     '_label -> Html(Messages("iht.address.line4")))
 
 
@@ -82,7 +82,7 @@
     true,
     '_inputClass -> "form-control",
     '_label -> Html(Messages("iht.country")),
-    '_labelTextClass -> "form-label",
+    '_labelTextClass -> "bold",
     '_id -> Messages("page.iht.registration.registrationSummary.deceasedInfo.countryCode.id"),
     '_labelid -> "ukAddress.countryCode-container",
     '_emptyValueText -> " "

--- a/app/iht/views/registration/deceased/deceased_address_details_uk.scala.html
+++ b/app/iht/views/registration/deceased/deceased_address_details_uk.scala.html
@@ -45,7 +45,7 @@
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_divClass -> "form-group ",
     '_inputClass -> "form-control",
-    '_labelTextClass -> "form-label ",
+    '_labelTextClass -> "bold ",
     '_label -> Html(Messages("iht.address.line1")))
 
     @ihtHelpers.standard.input_with_help(
@@ -53,7 +53,7 @@
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_divClass -> "form-group ",
     '_inputClass -> "form-control",
-    '_labelTextClass -> "form-label ",
+    '_labelTextClass -> "bold ",
     '_label -> Html(Messages("iht.address.line2")))
 
     @ihtHelpers.standard.input_with_help(
@@ -61,7 +61,7 @@
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_divClass -> "form-group ",
     '_inputClass -> "form-control",
-    '_labelTextClass -> "form-label ",
+    '_labelTextClass -> "bold ",
     '_label -> Html(Messages("iht.address.line3")))
 
     @ihtHelpers.standard.input_with_help(
@@ -69,7 +69,7 @@
     '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
     '_divClass -> "form-group ",
     '_inputClass -> "form-control",
-    '_labelTextClass -> "form-label ",
+    '_labelTextClass -> "bold ",
     '_label -> Html(Messages("iht.address.line4")))
 
     @ihtHelpers.standard.input_with_help(
@@ -77,7 +77,7 @@
     '_maxlength -> IhtProperties.validationMaxLengthPostcode,
     '_divClass -> "form-group",
     '_inputClass -> "form-control form-control-1-4",
-    '_labelTextClass -> "form-label ",
+    '_labelTextClass -> "bold ",
     '_label -> Html(Messages("iht.postcode")))
 
     <p>@ihtHelpers.custom.return_link(Messages("iht.registration.changeAddressToAbroad"),Some(changeNationalityLocation))</p>

--- a/app/iht/views/registration/deceased/deceased_address_question.scala.html
+++ b/app/iht/views/registration/deceased/deceased_address_question.scala.html
@@ -49,7 +49,7 @@ hasTimeOut=true) {
         '_extraText -> Html("<p class=\"lede\">" + Messages("page.iht.registration.deceasedAddressQuestion.p1", StringEscapeUtils.escapeHtml4(deceasedName)) + "</p><p class=\"lede\">" + Messages("page.iht.registration.deceasedAddressQuestion.p2") + "</p>")
     )
 
-      <input id = 'continue-button' class='button' type='submit' value='@Messages("iht.continue")' />
+      <input id='continue-button' class='button' type='submit' value='@Messages("iht.continue")' />
     }
 
 }

--- a/app/iht/views/registration/executor/others_applying_for_probate_address.scala.html
+++ b/app/iht/views/registration/executor/others_applying_for_probate_address.scala.html
@@ -47,27 +47,27 @@
       @ihtHelpers.standard.input_with_help(othersApplyingForProbateAddressForm("ukAddressLine1"),
         '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
         '_inputClass -> "form-control ",
-        '_labelTextClass -> "form-label",
+        '_labelTextClass -> "bold",
         '_label -> Html(Messages("iht.address.line1")))
         </div>
     <div id="ukAddress_ukAddressLine2-container" class="form-group">
       @ihtHelpers.standard.input_with_help(othersApplyingForProbateAddressForm("ukAddressLine2"),
         '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
         '_inputClass -> "form-control ",
-        '_labelTextClass -> "form-label",
+        '_labelTextClass -> "bold",
         '_label -> Html(Messages("iht.address.line2")))
     </div>
     <div id="ukAddress_ukAddressLine3-container" class="form-group">
       @ihtHelpers.standard.input_with_help(othersApplyingForProbateAddressForm("ukAddressLine3"),
         '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
         '_inputClass -> "form-control ",
-        '_labelTextClass -> "form-label",
+        '_labelTextClass -> "bold",
         '_label -> Html(Messages("iht.address.line3")))
     </div>
     <div id="ukAddress_ukAddressLine4-container" class="form-group">
       @ihtHelpers.standard.input_with_help(othersApplyingForProbateAddressForm("ukAddressLine4"),
         '_maxlength -> IhtProperties.validationMaxLengthAddresslines,
-        '_inputClass -> "form-control ", '_labelTextClass -> "form-label",
+        '_inputClass -> "form-control ", '_labelTextClass -> "bold",
         '_label -> Html(Messages("iht.address.line4")))
     </div>
 
@@ -83,7 +83,7 @@
         '_labelid -> "countryCode-container",
         '_emptyValueText -> " ",
         '_emptyValue -> "GB",
-        '_labelClass -> "form-label",
+        '_labelClass -> "bold",
         '_label -> Html(Messages("iht.country"))
         )
     </div>
@@ -95,7 +95,7 @@
             '_maxlength -> IhtProperties.validationMaxLengthPostcode,
             '_divClass -> "form-group",
             '_inputClass -> "form-control form-control-1-4",
-            '_labelTextClass -> "form-label",
+            '_labelTextClass -> "bold",
           '_label -> Html(Messages("iht.postcode")))
       </div>
       <a href="@changeNationalityLocation">@Messages("iht.registration.changeAddressToAbroad")</a>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -2232,7 +2232,7 @@ error.postcode.invalid.character = This line contains an invalid character. Vali
 error.problem = There is a problem
 error.report.redo = Select the estate report through the Your Inheritance Tax estate reports page and send the details again.
 error.selectAnswer = Select an answer
-error.selectAnswer.summary = select an answer
+error.selectAnswer.summary = Select an answer
 error.signOutLater = Sign out and complete this service at another time.
 error.value.blank = A value should be entered
 


### PR DESCRIPTION
This means error messages pass accessibility/contrast checks now, and includes the following changes and updates:
- addition of form_validation.scss with required styles
- update classes to adopt styles
- update markup (as much as possible in scope) so the hint text in contained within the error parent wrapper
- update all labels to have matching .bold class for consistency across service

## Before and after screenshots

![iht-before-after-errors](https://user-images.githubusercontent.com/1692222/40105545-278699a8-58eb-11e8-808e-651f2ecbc918.jpg)
