### PR TITLE
DL-1035 - Making amendments to guidance for users on estate report

### DIFF
--- a/app/iht/controllers/estateReports/YourEstateReportsController.scala
+++ b/app/iht/controllers/estateReports/YourEstateReportsController.scala
@@ -65,17 +65,17 @@ trait YourEstateReportsController extends ApplicationController {
             })
 
             futureViewModels.map(seqOfModels =>
-              Ok(iht.views.html.estateReports.your_estate_reports(seqOfModels))
+              Ok(iht.views.html.estateReports.your_estate_reports(seqOfModels, showGuidance(seqOfModels)))
                 .withSession(request.session + (SessionKeys.sessionId -> s"session-${UUID.randomUUID}") + (Constants.NINO -> nino)))
           }
 
           case _ =>
-            Future.successful(Ok(iht.views.html.estateReports.your_estate_reports(Nil)).withSession(
+            Future.successful(Ok(iht.views.html.estateReports.your_estate_reports(Nil, false)).withSession(
               SessionHelper.ensureSessionHasNino(request.session, user) +
                 (SessionKeys.sessionId -> s"session-${UUID.randomUUID}")))
         } recover {
           case e: Upstream4xxResponse if e.upstreamResponseCode == 404 =>
-            Ok(iht.views.html.estateReports.your_estate_reports(Nil)).withSession(
+            Ok(iht.views.html.estateReports.your_estate_reports(Nil, false)).withSession(
               SessionHelper.ensureSessionHasNino(request.session, user) +
                 (SessionKeys.sessionId -> s"session-${UUID.randomUUID}")
             )
@@ -99,5 +99,10 @@ trait YourEstateReportsController extends ApplicationController {
         DeceasedInfoHelper.determineStatusToUse(ihtApp.currentStatus, CommonHelper.getOrExceptionNoApplication(appDetails).status)
       }
     }
+  }
+
+  def showGuidance(applications: Seq[YourEstateReportsRowViewModel]): Boolean = {
+    val targetStatuses = Set(AppStatus.InReview.toLowerCase , AppStatus.Closed.toLowerCase, "o dan adolygiad", "wedi cau")
+    applications map (_.currentStatus.toLowerCase) exists targetStatuses
   }
 }

--- a/app/iht/views/estateReports/your_estate_reports.scala.html
+++ b/app/iht/views/estateReports/your_estate_reports.scala.html
@@ -16,37 +16,70 @@
 
 @import iht.viewmodels.estateReports.YourEstateReportsRowViewModel
 @import uk.gov.hmrc.play.partials.FormPartialRetriever
-
-@(applications:Seq[YourEstateReportsRowViewModel])(implicit request:Request[_], messages: Messages, ihtFormPartialRetriever: FormPartialRetriever)
-
+@(applications:Seq[YourEstateReportsRowViewModel], showGuidance: Boolean)(implicit request:Request[_], messages: Messages, ihtFormPartialRetriever: FormPartialRetriever)
 @import uk.gov.hmrc.play.views.html._
 @import iht.views.html._
 
-@iht_main_template_application(title = Messages("page.iht.home.title"),
-browserTitle=Some(Messages("page.iht.home.browserTitle")),
-isFullWidth=true) {
+    @personalDetailsReveal = {
+        <details id="personal-details-reveal">
+            <summary>
+                <span class="summary">@Messages("iht.estateReport.personalDetails.error.title")</span>
+            </summary>
+            <div class="panel panel-border-narrow">
+                <p>@Messages("iht.estateReport.personalDetails.error.p1")</p>
+                <p>@Messages("iht.estateReport.personalDetails.error.p2")</p>
+                <p>@Messages("iht.estateReport.personalDetails.error.p3")</p>
+            </div>
+        </details>
+        <details id="estate-value-reveal">
+            <summary>
+                <span class="summary">@Messages("iht.estateReport.estateValue.error.title")</span>
+            </summary>
+            <div class="panel panel-border-narrow">
+                <p>@Messages("iht.estateReport.estateValue.error.p1")</p>
+                <a id="estate-value-error" href="@iht.controllers.filter.routes.DomicileController.onPageLoad().url">
+                    @Messages("iht.estateReport.estateValue.error.link")
+                </a>
+                <p>@Messages("iht.estateReport.estateValue.error.p2")</p>
+            </div>
+        </details>
+    }
+    @personalDetailsSubmittedReveal = {
+        <details id="personal-details-submitted-reveal">
+            <summary>
+                <span class="summary">@Messages("iht.estateReport.personalDetails.error.title")</span>
+            </summary>
+            <div class="panel panel-border-narrow">
+                <p>@Messages("iht.estateReport.personalDetails.submitted.error.p1")</p>
+                <p>@Messages("iht.estateReport.personalDetails.submitted.error.p2")</p>
+                <p>@Messages("iht.estateReport.personalDetails.submitted.error.p3")</p>
+            </div>
+        </details>
+    }
 
-@if(applications.isEmpty){
+    @iht_main_template_application(title = Messages("page.iht.home.title"),
+    browserTitle=Some(Messages("page.iht.home.browserTitle")),
+    isFullWidth=true) {
 
-	<p class="grid-2-3">@Messages("page.iht.home.applicationList.table.guidance.label.empty")</p>
+    @if(applications.isEmpty){
+        <p class="grid-2-3">@Messages("page.iht.home.applicationList.table.guidance.label.empty")</p>
+        <div class="panel panel-border-wide grid-2-3">
+            <p>@Messages("page.iht.home.text")</p>
+        </div>
+    } else {
+        <p class="grid-2-3">@Messages("page.iht.home.applicationList.table.guidance.label")</p>
+        <div class="panel panel-border-wide grid-2-3">
+            <p>@Messages("page.iht.home.text")</p>
+        </div>
+    @your_estate_reports_application_table(applications)
+    }
 
-	<div class="panel panel-border-wide grid-2-3">
-	    <p>@Messages("page.iht.home.text")</p>
-	</div>
-
-} else {
-	<p class="grid-2-3">@Messages("page.iht.home.applicationList.table.guidance.label")</p>
-
-	<div class="panel panel-border-wide grid-2-3">
-	    <p>@Messages("page.iht.home.text")</p>
-	</div>
-
-   @your_estate_reports_application_table(applications)
-}
 <a id="start-new-registration" href="@iht.controllers.registration.routes.RegistrationChecklistController.onPageLoad()">@Messages("site.link.startNewRegistration")</a>
+<h3>@Messages("iht.estateReport.help")</h3>
 
-@if(applications.isEmpty){
-   <p class="grid-2-3">@Messages("page.iht.home.applicationList.table.guidance.p2.empty")</p>
-}
+    @if(showGuidance) { @personalDetailsReveal } else { @personalDetailsSubmittedReveal }
 
+    @if(applications.isEmpty){
+        <p class="grid-2-3">@Messages("page.iht.home.applicationList.table.guidance.p2.empty")</p>
+    }
 }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -2166,3 +2166,19 @@ page.iht.application.exemptions.guidance.increasing.threshold.link.text = Yn ôl
 
 global.error.InternalServerError500.message1 = Os gwelwch y neges hon sawl gwaith, gallwch ddewis rhoi gwybod am werth yr ystâd gan ddefnyddio <a id="paperFormLink" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459774/IHT205_2011__Cymraeg.pdf">ffurflen bapur IHT205</a>
 
+#Estate Report - Get Help
+iht.estateReport.help = Help gyda’ch adroddiadau ynghylch yr ystâd
+
+iht.estateReport.personalDetails.error.title = Os ydych wedi gwneud camgymeriadau o ran manylion personol
+iht.estateReport.personalDetails.submitted.error.p1 = Nid oes rhaid i chi roi gwybod i CThEM am unrhyw newidiadau neu gamgymeriadau o ran enwau, rhifau, cyfeiriadau neu ddyddiadau, neu ddileu neu ychwanegu ysgutorion.
+iht.estateReport.personalDetails.submitted.error.p2 = Rhaid i chi sicrhau bod yr ysgutorion wedi’u rhestru’n gywir ar y cais ar gyfer profiant.
+iht.estateReport.personalDetails.submitted.error.p3 = Os oes angen adroddiad arnoch yn bersonol ynghylch yr ystâd, gyda manylion personol wedi’u diwygio, bydd angen i chi gofrestru’r ystâd eto.
+
+iht.estateReport.personalDetails.error.p1 = Pan fo’ch adroddiad o dan adolygiad neu wedi’i gau, ni allwch ei ailagor na dechrau un newydd.
+iht.estateReport.personalDetails.error.p2 = Nid oes rhaid i chi roi gwybod i CThEM am unrhyw newidiadau neu gamgymeriadau o ran enwau, rhifau, cyfeiriadau neu ddyddiadau, neu ddileu neu ychwanegu ysgutorion.
+iht.estateReport.personalDetails.error.p3 = Rhaid i chi sicrhau bod yr ysgutorion wedi’u rhestru’n gywir ar y cais ar gyfer profiant.
+
+iht.estateReport.estateValue.error.title = Os ydych wedi gwneud camgymeriadau o ran gwerth yr ystâd
+iht.estateReport.estateValue.error.p1 = Nid oes rhaid i chi roi gwybod i CThEM am unrhyw newidiadau o ran gwerth yr ystâd oni bai eich bod o’r farn y gallai fod angen i chi gyflwyno Ffurflen Dreth lawn (IHT400). Os oes angen Ffurflen Dreth lawn, ac nid ydych yn cyflwyno un, mae’n bosibl y codir cosb arnoch.
+iht.estateReport.estateValue.error.link = Ewch ati i gadarnhau a oes angen Ffurflen Dreth lawn ar yr ystâd.
+iht.estateReport.estateValue.error.p2 = Mae’n rhaid i chi, ym mhob achos, roi gwybod i’r Gwasanaeth Profiant am werth yr ystâd wedi’i ddiwygio (gros a net) hyd nes eich bod yn cael y Grant Profiant.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -601,6 +601,22 @@ iht.estateReport.ihtThreshold = Inheritance Tax threshold
 iht.estateReport.noInheritanceTaxPayable = no Inheritance Tax is payable
 iht.inheritanceTaxEstateReport = Inheritance Tax estate report
 
+#Estate Report - Get Help
+iht.estateReport.help = Help with your estate reports
+iht.estateReport.personalDetails.error.title = If you made errors in personal details
+iht.estateReport.personalDetails.submitted.error.p1 = You do not need to inform HMRC of any changes or errors in names, numbers, addresses or dates, or the removal or addition of executors.
+iht.estateReport.personalDetails.submitted.error.p2 = You must ensure the executors are listed correctly on the probate application.
+iht.estateReport.personalDetails.submitted.error.p3 = If you personally need an estate report with amended personal details you will need to register the estate again.
+
+iht.estateReport.personalDetails.error.p1 = Once your report is in review or closed, you cannot re-open it or start a new one.
+iht.estateReport.personalDetails.error.p2 = You do not need to inform HMRC of any changes or errors in names, numbers, addresses or dates, or the removal or addition of executors.
+iht.estateReport.personalDetails.error.p3 = You must ensure the executors are listed correctly on the probate application.
+
+iht.estateReport.estateValue.error.title = If you made errors in estate value
+iht.estateReport.estateValue.error.p1 = You do not need to report any changes in estate value to HMRC unless you think you might need to submit a full return (IHT400). If a full return is needed and you do not make one, you may get a penalty.
+iht.estateReport.estateValue.error.link = Check if the estate needs a full return.
+iht.estateReport.estateValue.error.p2 = You must in all cases report the amended estate value (gross and net) to the Probate Service until the time you get the Grant of Probate.
+
 #Estate report - IhtHome
 page.iht.home.title = Your Inheritance Tax estate reports
 page.iht.home.text = Save the link to this page or add it to your favourites. You’ll then be able to return to add or edit details before you submit the completed report to HMRC.
@@ -624,7 +640,6 @@ page.iht.exit.title = Save your estate report
 page.iht.exit.text = Save this link to your estate report so you can access it when you are ready to add details to it.
 page.iht.exit.button = Exit
 page.iht.exit.link = https://www.tax.service.gov.uk/inheritance-tax/estate-report
-
 
 #Estate report - Application Status - In Review
 page.iht.application.overview.inreview.title = We are reviewing {0}’s estate report

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -11,16 +11,16 @@ private object AppDependencies {
   import play.sbt.PlayImport._
   import play.core.PlayVersion
 
-  private val httpCachingClientVersion = "7.1.0"
+  private val httpCachingClientVersion = "7.2.0"
   private val jsonSchemaValidatorVersion = "2.2.6"
   private val jsonVersion = "20180130"
   private val wireMockVersion = "2.9.0"
 
 val compile = Seq(
   ws, cache,
-  "uk.gov.hmrc" %% "url-builder" % "2.1.0",
+  "uk.gov.hmrc" %% "url-builder" % "3.0.0",
   "uk.gov.hmrc" %% "http-caching-client" % httpCachingClientVersion,
-  "uk.gov.hmrc" %% "frontend-bootstrap" % "10.3.0",
+  "uk.gov.hmrc" %% "frontend-bootstrap" % "10.7.0",
   "uk.gov.hmrc" %% "play-partials" % "6.1.0",
   "uk.gov.hmrc" %% "domain" % "5.2.0",
   "uk.gov.hmrc" %% "play-language" % "3.4.0",
@@ -38,7 +38,7 @@ object Test {
   def apply() = new TestDependencies {
     override lazy val test = Seq(
       "uk.gov.hmrc" %% "http-caching-client" % httpCachingClientVersion % scope,
-      "uk.gov.hmrc" %% "hmrctest" % "3.0.0" % scope,
+      "uk.gov.hmrc" %% "hmrctest" % "3.2.0" % scope,
       "org.scalatest" %% "scalatest" % "3.0.0" % scope,
       "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0",
       "org.pegdown" % "pegdown" % "1.6.0" % scope,

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -105,7 +105,7 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*\$]]></parameter>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">

--- a/test/iht/testhelpers/viewSpecshelper/estateReport/EstateReportMessage.scala
+++ b/test/iht/testhelpers/viewSpecshelper/estateReport/EstateReportMessage.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iht.testhelpers.viewSpecshelper.estateReport
+
+trait EstateReportMessage {
+
+  val estateReportMessageTitle = "Help with your estate reports"
+
+  val estateReportPersonalDetailsErrorTitle = "If you made errors in personal details"
+
+  val estateReportPersonalDetailsSubmittedErrorP1 = "You do not need to inform HMRC of any changes or errors in names, numbers, addresses or dates, or the removal or addition of executors."
+  val estateReportPersonalDetailsSubmittedErrorP2 = "You must ensure the executors are listed correctly on the probate application."
+  val estateReportPersonalDetailsSubmittedErrorP3 = "If you personally need an estate report with amended personal details you will need to register the estate again."
+
+  val estateReportPersonalDetailsErrorP1 = "Once your report is in review or closed, you cannot re-open it or start a new one."
+  val estateReportPersonalDetailsErrorP2 = "You do not need to inform HMRC of any changes or errors in names, numbers, addresses or dates, or the removal or addition of executors."
+  val estateReportPersonalDetailsErrorP3 = "You must ensure the executors are listed correctly on the probate application."
+
+  val estateReportEstateValueErrorTitle = "If you made errors in estate value"
+  val estateReportEstateValueErrorP1 = "You do not need to report any changes in estate value to HMRC unless you think you might need to submit a full return (IHT400). If a full return is needed and you do not make one, you may get a penalty."
+  val estateReportEstateValueErrorLink = "Check if the estate needs a full return."
+  val estateReportEstateValueErrorP2 = "You must in all cases report the amended estate value (gross and net) to the Probate Service until the time you get the Grant of Probate."
+
+}

--- a/test/iht/views/estateReports/YourEstateReportsViewTest.scala
+++ b/test/iht/views/estateReports/YourEstateReportsViewTest.scala
@@ -27,17 +27,19 @@ import play.api.i18n.Messages.Implicits._
 import play.api.i18n.MessagesApi
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
+import iht.testhelpers.viewSpecshelper.estateReport.EstateReportMessage
+import play.api.i18n.Messages.Implicits._
 
-class YourEstateReportsViewTest extends ViewTestHelper with ApplicationControllerTest {
+class YourEstateReportsViewTest extends ViewTestHelper with ApplicationControllerTest with EstateReportMessage {
 
   override implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
   var mockIhtConnector = mock[IhtConnector]
-  lazy val registrationChecklistPageUrl= iht.controllers.registration.routes.RegistrationChecklistController.onPageLoad()
+  lazy val registrationChecklistPageUrl = iht.controllers.registration.routes.RegistrationChecklistController.onPageLoad()
 
   def ihtHomeView(ihtApplications: Seq[YourEstateReportsRowViewModel] = Nil) = {
     implicit val request = createFakeRequest()
 
-    val view = your_estate_reports(ihtApplications).toString()
+    val view = your_estate_reports(ihtApplications, false).toString()
     asDocument(view)
   }
 
@@ -54,43 +56,56 @@ class YourEstateReportsViewTest extends ViewTestHelper with ApplicationControlle
 
   "IhtHome view" must {
     "have no message keys in html" in {
-        val view = ihtHomeView(ihtApplications).toString
-        noMessageKeysShouldBePresent(view)
+      val view = ihtHomeView(ihtApplications).toString
+      noMessageKeysShouldBePresent(view)
     }
 
     "have correct title and browser title " in {
-        val view = ihtHomeView(ihtApplications).toString
-        titleShouldBeCorrect(view, messagesApi("page.iht.home.title"))
-        browserTitleShouldBeCorrect(view, messagesApi("page.iht.home.browserTitle"))
+      val view = ihtHomeView(ihtApplications).toString
+      titleShouldBeCorrect(view, messagesApi("page.iht.home.title"))
+      browserTitleShouldBeCorrect(view, messagesApi("page.iht.home.browserTitle"))
     }
 
     "have correct guidance paragraphs when case list have records" in {
-        val view = ihtHomeView(ihtApplications).toString
-        messagesShouldBePresent(view, messagesApi("page.iht.home.applicationList.table.guidance.label"))
+      val view = ihtHomeView(ihtApplications).toString
+      messagesShouldBePresent(view, messagesApi("page.iht.home.applicationList.table.guidance.label"))
     }
 
     "show all the table headers when case list have records" in {
-        val view = ihtHomeView(ihtApplications)
-        assertEqualsValue(view, "th#deceased-name-header", messagesApi("page.iht.home.deceasedName.label"))
-        assertEqualsValue(view, "th#iht-reference-header", messagesApi("page.iht.home.ihtReference.label"))
-        assertEqualsValue(view, "th#date-of-death-header", messagesApi("iht.dateOfDeath"))
-        assertEqualsValue(view, "th#status-header", messagesApi("page.iht.home.currentStatus"))
+      val view = ihtHomeView(ihtApplications)
+      assertEqualsValue(view, "th#deceased-name-header", messagesApi("page.iht.home.deceasedName.label"))
+      assertEqualsValue(view, "th#iht-reference-header", messagesApi("page.iht.home.ihtReference.label"))
+      assertEqualsValue(view, "th#date-of-death-header", messagesApi("iht.dateOfDeath"))
+      assertEqualsValue(view, "th#status-header", messagesApi("page.iht.home.currentStatus"))
     }
 
     "have correct guidance paragraphs when the case list is empty" in {
-        val view = ihtHomeView().toString
-        messagesShouldBePresent(view, messagesApi("page.iht.home.applicationList.table.guidance.label.empty"))
-        messagesShouldBePresent(view, messagesApi("page.iht.home.applicationList.table.guidance.p2.empty"))
+      val view = ihtHomeView().toString
+      messagesShouldBePresent(view, messagesApi("page.iht.home.applicationList.table.guidance.label.empty"))
+      messagesShouldBePresent(view, messagesApi("page.iht.home.applicationList.table.guidance.p2.empty"))
     }
 
     "have link to start new registration with correct text" in {
-        val view = ihtHomeView(ihtApplications)
+      val view = ihtHomeView(ihtApplications)
 
-        val returnLink = view.getElementById("start-new-registration")
-        returnLink.attr("href") shouldBe registrationChecklistPageUrl.url
-        returnLink.text() shouldBe messagesApi("site.link.startNewRegistration")
+      val returnLink = view.getElementById("start-new-registration")
+      returnLink.attr("href") shouldBe registrationChecklistPageUrl.url
+      returnLink.text() shouldBe messagesApi("site.link.startNewRegistration")
 
     }
+
   }
 
+  "Progressive disclosure default" should {
+
+    "display personal details submitted reveal" in {
+      val view = ihtHomeView(ihtApplications)
+
+      val detailsReveal = view.getElementById("personal-details-submitted-reveal")
+
+      detailsReveal.select("p").get(0).text() shouldBe estateReportPersonalDetailsSubmittedErrorP1
+      detailsReveal.select("p").get(1).text() shouldBe estateReportPersonalDetailsSubmittedErrorP2
+      detailsReveal.select("p").get(2).text() shouldBe estateReportPersonalDetailsSubmittedErrorP3
+    }
+  }
 }


### PR DESCRIPTION
# DL-1035 - Implement disclosure changes to estate report view

**New feature**

Implementing dynamic disclosure panels for personalDetailsReveal and personalDetailSubmittedReveal which are dependant upon whether an application(s) are in a 'Closed' or 'In review' status. If these statuses exist then show 2 disclosure guides on the estate review page (personalDetailsReveal and estateValueReveal) else display 1 disclosure guide for personalDetailsSubmittedReveal.

We have had to convert the status returned to lower case due to the unique way in which IHT renders the status: 'In Review' is rendered as 'In review' on the view and also include string checks for Welsh translation as language conversion process does not appear to be handles as part of ApplicationStatus.

Note where no status is present default  personalDetailsSubmittedReveal will be rendered

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
