### PR TITLE
Dl 1757

### DIFF
--- a/app/iht/views/registration/applicant/executor_of_estate.scala.html
+++ b/app/iht/views/registration/applicant/executor_of_estate.scala.html
@@ -43,7 +43,7 @@ hasTimeOut=true) {
     '_fieldsetId -> "executor-of-estate",
     '_divClass -> "form-group",
     '_legendIsHeading -> true,
-    '_extraText -> Html("<p class=\"lede\">" + Messages("page.iht.registration.applicant.executorOfEstate.p1") + "</p>")
+    '_extraText -> Html("<p>" + Messages("page.iht.registration.applicant.executorOfEstate.p1") + "</p>")
   )
 
 @ihtHelpers.custom.continue_button()

--- a/app/iht/views/registration/deceased/deceased_address_question.scala.html
+++ b/app/iht/views/registration/deceased/deceased_address_question.scala.html
@@ -43,7 +43,7 @@ hasTimeOut=true) {
         '_fieldsetId -> "last-contact-address-in-uk",
         '_divClass -> Some("form-group"),
         '_legendIsHeading -> true,
-        '_extraText -> Html("<p class=\"lede\">" + Messages("page.iht.registration.deceasedAddressQuestion.p1", StringEscapeUtils.escapeHtml4(deceasedName)) + "</p><p class=\"lede\">" + Messages("page.iht.registration.deceasedAddressQuestion.p2") + "</p>")
+        '_extraText -> Html("<p>" + Messages("page.iht.registration.deceasedAddressQuestion.p1", StringEscapeUtils.escapeHtml4(deceasedName)) + "</p><p>" + Messages("page.iht.registration.deceasedAddressQuestion.p2") + "</p>")
     )
 
       <input id='continue-button' class='button' type='submit' value='@Messages("iht.continue")' />

--- a/app/iht/views/registration/executor/coexecutor_personal_details.scala.html
+++ b/app/iht/views/registration/executor/coexecutor_personal_details.scala.html
@@ -31,7 +31,7 @@ cancelLocation: Option[Call] = None)(implicit request : Request[_], messages: Me
   isFullWidth=false,
   cancelUrl=cancelLocation,
   hasTimeOut=true,
-  headingClass=Some("heading-large")) {
+  headingClass="heading-xlarge") {
 
 @ihtHelpers.custom.error_summary(coExecutorDetails, Some(
     Map(

--- a/app/iht/views/registration/executor/executor_overview.scala.html
+++ b/app/iht/views/registration/executor/executor_overview.scala.html
@@ -35,7 +35,7 @@
 @ihtHelpers.custom.error_summary(addMoreCoExecutorsForm)
 
 @form(action = actionCall,'autoComplete -> "off") {
-  <p class="lede">@Messages("page.iht.registration.executor-overview.description")</p>
+  <p>@Messages("page.iht.registration.executor-overview.description")</p>
 
 
   <div class="grid-layout grid-layout--maintain-width grid-layout--nogutter divider--bottom section">

--- a/app/iht/views/registration/executor/others_applying_for_probate.scala.html
+++ b/app/iht/views/registration/executor/others_applying_for_probate.scala.html
@@ -44,7 +44,7 @@ hasTimeOut=true) {
     '_legendClass -> Some("legend-with-heading"),
     '_fieldsetId -> "answer",
     '_legendIsHeading -> true,
-    '_headingClass -> "heading-large",
+    '_headingClass -> "heading-xlarge",
     '_extraText -> Html("<p>" + Messages("page.iht.registration.others-applying-for-probate.description") + "</p>")
 
 )

--- a/app/iht/views/registration/executor/others_applying_for_probate.scala.html
+++ b/app/iht/views/registration/executor/others_applying_for_probate.scala.html
@@ -45,7 +45,7 @@ hasTimeOut=true) {
     '_fieldsetId -> "answer",
     '_legendIsHeading -> true,
     '_headingClass -> "heading-large",
-    '_extraText -> Html("<p class=\"lede\">" + Messages("page.iht.registration.others-applying-for-probate.description") + "</p>")
+    '_extraText -> Html("<p>" + Messages("page.iht.registration.others-applying-for-probate.description") + "</p>")
 
 )
 

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -18,14 +18,14 @@ private object AppDependencies {
 
   val compile = Seq(
     ws, cache,
-    "uk.gov.hmrc" %% "url-builder" % "3.0.0",
+    "uk.gov.hmrc" %% "url-builder" % "3.1.0",
     "uk.gov.hmrc" %% "http-caching-client" % httpCachingClientVersion,
-    "uk.gov.hmrc" %% "bootstrap-play-25" % "4.7.0",
-    "uk.gov.hmrc" %% "auth-client" % "2.19.0-play-25",
+    "uk.gov.hmrc" %% "bootstrap-play-25" % "4.9.0",
+    "uk.gov.hmrc" %% "auth-client" % "2.20.0-play-25",
     "uk.gov.hmrc" %% "play-partials" % "6.5.0",
-    "uk.gov.hmrc" %% "domain" % "5.3.0",
-    "uk.gov.hmrc" %% "govuk-template" % "5.28.0-play-25",
-    "uk.gov.hmrc" %% "play-ui" % "7.32.0-play-25",
+    "uk.gov.hmrc" %% "domain" % "5.6.0-play-25",
+    "uk.gov.hmrc" %% "govuk-template" % "5.30.0-play-25",
+    "uk.gov.hmrc" %% "play-ui" % "7.35.0-play-25",
     "uk.gov.hmrc" %% "play-language" % "3.4.0",
     "com.github.fge" % "json-schema-validator" % jsonSchemaValidatorVersion,
     "org.apache.xmlgraphics" % "fop" % "2.1",
@@ -41,7 +41,7 @@ private object AppDependencies {
     def apply() = new TestDependencies {
       override lazy val test = Seq(
         "uk.gov.hmrc" %% "http-caching-client" % httpCachingClientVersion % scope,
-        "uk.gov.hmrc" %% "hmrctest" % "3.5.0-play-25" % scope,
+        "uk.gov.hmrc" %% "hmrctest" % "3.6.0-play-25" % scope,
         "org.scalatest" %% "scalatest" % "3.0.0" % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0",
         "org.pegdown" % "pegdown" % "1.6.0" % scope,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,13 +4,13 @@ resolvers += "SBT Releases" at "https://dl.bintray.com/sbt/sbt-plugin-releases"
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 resolvers += "scoverage-bintray" at "https://dl.bintray.com/sksamuel/sbt-plugins/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.15.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.17.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.3.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.17.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.18.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
 


### PR DESCRIPTION
DL 1757 - removing unwanted class from registration journey

**Fix** 

Removing the use if class 'lede' in registration journey as rendering of info detail is inconsistent. At the same time it was observed that there was a mix and match of h1 sizes. These have been standardised to the 'heading-xlarge' as per Gov UK Elements documentation. Upgraded dependencies and plugins to latest available and executed acceptance tests and performance tests locally.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date