### PR TITLE
DL-2337 Stop showing the platforms internal address to end users

### DIFF
--- a/app/iht/constants/IhtProperties.scala
+++ b/app/iht/constants/IhtProperties.scala
@@ -82,6 +82,7 @@ trait IhtProperties extends IhtPropertyRetriever {
   lazy val linkContactHMRC: String = getProperty("linkContactHMRC")
   lazy val linkLandRegistry: String = getProperty("linkLandRegistry")
   lazy val linkPayEarly: String = getProperty("linkPayEarly")
+  lazy val frontendBaseUrl: String = getProperty("frontend-base-url")
   lazy val charityLink: String = getProperty("charityLink")
   lazy val correctiveAccountsLink: String = getProperty("correctiveAccountLink")
   lazy val giftsStartDay: Int = getPropertyAsInt("giftsStartDay")

--- a/app/iht/views/iv/failurepages/locked_out.scala.html
+++ b/app/iht/views/iv/failurepages/locked_out.scala.html
@@ -23,7 +23,7 @@
 
 @defining(Messages("page.iht.iv.failure.lockedOut.heading")) { pageTitle =>
   @iht_main_template_application(title = pageTitle, browserTitle = Some(pageTitle)) {
-    <p data-journey="iv-failure:page-view:locked-out">@Html(Messages("page.iht.iv.failure.lockedOut.tryAgain", iht.controllers.registration.routes.RegistrationChecklistController.onPageLoad.absoluteURL))</p>
+    <p data-journey="iv-failure:page-view:locked-out">@Html(Messages("page.iht.iv.failure.lockedOut.tryAgain", {appConfig.frontendBaseUrl + iht.controllers.registration.routes.RegistrationChecklistController.onPageLoad.url }))</p>
     <p>@Messages("page.iht.iv.failure.youCanAlso")</p>
     <ul class="list-bullet">
       <li>@Html(Messages("page.iht.iv.failure.reportWithPaperForm", appConfig.linkIHT205PDF))</li>

--- a/app/iht/views/iv/failurepages/technical_issue.scala.html
+++ b/app/iht/views/iv/failurepages/technical_issue.scala.html
@@ -23,7 +23,7 @@
 
 @defining(Messages("page.iht.iv.failure.technicalIssue.heading")) { pageTitle =>
   @iht_main_template_application(title = pageTitle, browserTitle = Some(pageTitle)) {
-    <p data-journey="iv-failure:page-view:technical-issue">@Html(Messages("page.iht.iv.failure.technicalIssue.tryAgain", iht.controllers.registration.routes.RegistrationChecklistController.onPageLoad.absoluteURL))</p>
+    <p data-journey="iv-failure:page-view:technical-issue">@Html(Messages("page.iht.iv.failure.technicalIssue.tryAgain", {appConfig.frontendBaseUrl + iht.controllers.registration.routes.RegistrationChecklistController.onPageLoad.url }))</p>
     <p>@Messages("page.iht.iv.failure.youCanAlso")</p>
     <ul class="list-bullet">
       <li>@Html(Messages("page.iht.iv.failure.reportWithPaperForm", appConfig.linkIHT205PDF))</li>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -110,7 +110,7 @@ microservice {
     }
     identity-verification {
       host = localhost
-      port = 9938
+      port = 9948
     }
     cachable {
       session-cache {
@@ -141,7 +141,7 @@ microservice {
       host="http://localhost:9949/auth-login-stub/gg-sign-in"
     }
     identity-verification-frontend {
-      host="http://localhost:9938"
+      host="http://localhost:9948"
     }
   }
 }

--- a/conf/iht.properties
+++ b/conf/iht.properties
@@ -81,6 +81,7 @@ charityLink=http://apps.charitycommission.gov.uk/showcharity/registerofcharities
 correctiveAccountLink=https://www.gov.uk/government/publications/inheritance-tax-corrective-account-c4
 linkContactHMRC=https://www.gov.uk/contact-hmrc
 linkLandRegistry=https://www.gov.uk/search-property-information-land-registry
+frontend-base-url=https://www.tax.service.gov.uk
 
 #Gifts
 giftsStartDay=6


### PR DESCRIPTION
# DL-2337 Stop showing the platforms internal address to end users

**Bug fix**

Production is showing an internal MDTP url to the user, this has been corrected in this PR.
![image](https://user-images.githubusercontent.com/11269301/64694034-9f082100-d490-11e9-8b3f-2bd2b299de67.png)

No dependancy updates have been performed as this is security related and needs to go to prod ASAP.

## Checklist

*Reviewee* (@grahampaulcook )
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
