### PR TITLE
DL-2395

### DIFF
--- a/app/iht/connector/IhtConnector.scala
+++ b/app/iht/connector/IhtConnector.scala
@@ -228,8 +228,9 @@ class IhtConnectorImpl @Inject()(val http: DefaultHttpClient,
 
   override def submitApplication(ihtAppReference: String, nino: String, applicationDetails: ApplicationDetails)
                                 (implicit headerCarrier: HeaderCarrier, request: Request[_]): Future[Option[String]] = {
+    val formattedNino = trimAndUpperCaseNino(nino)
     Logger.info("Submitting application")
-    http.POST(s"$serviceUrl/iht/$nino/$ihtAppReference/application/submit", applicationDetails, ihtHeaders).map(
+    http.POST(s"$serviceUrl/iht/$formattedNino/$ihtAppReference/application/submit", applicationDetails, ihtHeaders).map(
       response => response.status match {
         case OK =>
           Logger.info("Response received from Right for application submit")

--- a/app/iht/controllers/application/exemptions/partner/PartnerNinoController.scala
+++ b/app/iht/controllers/application/exemptions/partner/PartnerNinoController.scala
@@ -73,7 +73,7 @@ trait PartnerNinoController extends EstateController {
               lastName = existingLastName,
               dateOfBirth = existingDateOfBirth,
               totalAssets = existingTotalAssets,
-              nino = partnerExemption.nino) ))
+              nino = partnerExemption.ninoFormatted) ))
 
             case None => throw new RuntimeException("Partner Exemption does not exist")
           }

--- a/app/iht/controllers/registration/applicant/ApplicantTellUsAboutYourselfController.scala
+++ b/app/iht/controllers/registration/applicant/ApplicantTellUsAboutYourselfController.scala
@@ -121,7 +121,7 @@ trait ApplicantTellUsAboutYourselfController extends RegistrationApplicantContro
                 if (mode == Mode.Standard) {
                   rd.applicantDetails.getOrElse(new ApplicantDetails(role = Some(appConfig.roleLeadExecutor))) copy(firstName = person.firstName,
                     lastName = person.lastName, dateOfBirth = person.dateOfBirthLocalDate,
-                    nino = Some(nino.nino)) copy(phoneNo = ad.phoneNo, doesLiveInUK = ad.doesLiveInUK)
+                    nino = Some(ninoFormat(nino.nino))) copy(phoneNo = ad.phoneNo, doesLiveInUK = ad.doesLiveInUK)
                 } else {
                   rd.applicantDetails.getOrElse(new ApplicantDetails(role = Some(appConfig.roleLeadExecutor))) copy (phoneNo = ad.phoneNo)
                 }

--- a/app/iht/controllers/registration/deceased/AboutDeceasedController.scala
+++ b/app/iht/controllers/registration/deceased/AboutDeceasedController.scala
@@ -117,7 +117,7 @@ trait AboutDeceasedController extends RegistrationController with StringHelper {
               firstName = dd.firstName,
               lastName = dd.lastName,
               dateOfBirth = dd.dateOfBirth,
-              nino = dd.nino,
+              nino = dd.ninoFormatted,
               maritalStatus = dd.maritalStatus))
 
             val copyOfRD: RegistrationDetails = rd copy (deceasedDetails = optDDCopy)

--- a/app/iht/controllers/registration/executor/CoExecutorPersonalDetailsController.scala
+++ b/app/iht/controllers/registration/executor/CoExecutorPersonalDetailsController.scala
@@ -84,7 +84,7 @@ trait CoExecutorPersonalDetailsController extends RegistrationController with Co
     }
     else {
       val newId = iht.models.nextId(rd.coExecutors)
-      val coExec = coExecutor.copy(id = Some(newId))
+      val coExec = coExecutor.copy(id = Some(newId), nino = coExecutor.ninoFormatted)
       val route = getRoute(coExecutor.isAddressInUk.getOrElse(true), newId, mode)
       val newRd = rd.copy(coExecutors = rd.coExecutors :+ coExec)
       storeRegistrationDetails(newRd,

--- a/app/iht/models/Registration.scala
+++ b/app/iht/models/Registration.scala
@@ -17,7 +17,7 @@
 package iht.models
 
 import iht.config.AppConfig
-import iht.utils.{StringHelperFixture, ApplicationStatus => AppStatus}
+import iht.utils.{CommonHelper, StringHelperFixture, ApplicationStatus => AppStatus}
 import org.joda.time.LocalDate
 import play.api.Logger
 import play.api.libs.json.Json
@@ -44,10 +44,6 @@ case class ApplicantDetails(firstName: Option[String] = None,
 
   val name = firstName.getOrElse("") + " " + lastName.getOrElse("")
 
-  def ninoFormatted(implicit appConfig: AppConfig) = nino match {
-    case Some(n) => StringHelperFixture().ninoFormat(n)
-    case None => ""
-  }
 }
 
 object ApplicantDetails {
@@ -72,9 +68,8 @@ case class DeceasedDetails(firstName: Option[String] = None,
     nino.isDefined && ukAddress.isDefined &&
     dateOfBirth.isDefined && domicile.isDefined && maritalStatus.isDefined
 
-  def ninoFormatted(implicit appConfig: AppConfig) = nino match {
-    case Some(n) => StringHelperFixture().ninoFormat(n)
-    case None => ""
+  def ninoFormatted(implicit appConfig: AppConfig) = {
+    if (nino.isDefined) Some(StringHelperFixture().ninoFormat(CommonHelper.getOrException(nino))) else None
   }
 }
 
@@ -106,8 +101,8 @@ case class CoExecutor(id: Option[String] = None,
 
   val name = firstName + " " + lastName
 
-  def updatePersonalDetails(coExec: CoExecutor): CoExecutor =
-    CoExecutor(id, coExec.firstName, middleName, coExec.lastName, coExec.dateOfBirth, coExec.nino,
+  def updatePersonalDetails(coExec: CoExecutor)(implicit appConfig: AppConfig): CoExecutor =
+    CoExecutor(id, coExec.firstName, middleName, coExec.lastName, coExec.dateOfBirth, coExec.ninoFormatted,
       utr, ukAddress, ContactDetails(coExec.contactDetails.phoneNo, contactDetails.email), role, isAddressInUk)
 
   def ninoFormatted(implicit appConfig: AppConfig) = StringHelperFixture().ninoFormat(nino)

--- a/app/iht/models/application/exemptions/PartnerExemption.scala
+++ b/app/iht/models/application/exemptions/PartnerExemption.scala
@@ -16,7 +16,8 @@
 
 package iht.models.application.exemptions
 
-import iht.utils.CommonHelper
+import iht.config.AppConfig
+import iht.utils.{CommonHelper, StringHelperFixture}
 import org.joda.time.LocalDate
 import play.api.libs.json.{Json, OFormat}
 import play.api.libs.json.JodaWrites._
@@ -37,6 +38,9 @@ case class PartnerExemption(
       None
     }
 
+  def ninoFormatted(implicit appConfig: AppConfig) = {
+    if (nino.isDefined) Some(StringHelperFixture().ninoFormat(CommonHelper.getOrException(nino))) else None
+  }
   def isComplete: Option[Boolean] =
     isAssetForDeceasedPartner match {
       case Some(true) => isPartnerHomeInUK.fold(Some(false))(x => Some(x && firstName.isDefined &&

--- a/app/iht/utils/StringHelper.scala
+++ b/app/iht/utils/StringHelper.scala
@@ -47,10 +47,10 @@ trait StringHelper {
     if (s.length >= 9) {
       val str = s.replace(" ", "")
       (str.substring(StartOfPrefix, EndOfPrefix)
-        + " " + str.substring(FirstNumberStart, FirstNumberEnd)
-        + " " + str.substring(SecondNumberStart, SecondNumberEnd)
-        + " " + str.substring(ThirdNumberStart, ThirdNumberEnd)
-        + " " + str.substring(SuffixCharacter)).toUpperCase
+        + str.substring(FirstNumberStart, FirstNumberEnd)
+        + str.substring(SecondNumberStart, SecondNumberEnd)
+        + str.substring(ThirdNumberStart, ThirdNumberEnd)
+        + str.substring(SuffixCharacter)).toUpperCase
     } else {
       s
     }

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -11,10 +11,10 @@ private object AppDependencies {
   import play.sbt.PlayImport._
   import play.core.PlayVersion
 
-  private val httpCachingClientVersion = "8.4.0-play-26"
+  private val httpCachingClientVersion = "9.0.0-play-26"
   private val jsonSchemaValidatorVersion = "2.2.6"
   private val jsonVersion = "20180813"
-  private val wireMockVersion = "2.24.0"
+  private val wireMockVersion = "2.25.0"
 
   private val typesafe = "com.typesafe.play"
 
@@ -22,12 +22,12 @@ private object AppDependencies {
     ws, cache,
     "uk.gov.hmrc" %% "url-builder" % "3.1.0",
     "uk.gov.hmrc" %% "http-caching-client" % httpCachingClientVersion,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "0.42.0",
-    "uk.gov.hmrc" %% "auth-client" % "2.26.0-play-26",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.1.0",
+    "uk.gov.hmrc" %% "auth-client" % "2.30.0-play-26",
     "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-26",
     "uk.gov.hmrc" %% "domain" % "5.6.0-play-26",
-    "uk.gov.hmrc" %% "govuk-template" % "5.36.0-play-26",
-    "uk.gov.hmrc" %% "play-ui" % "7.40.0-play-26",
+    "uk.gov.hmrc" %% "govuk-template" % "5.43.0-play-26",
+    "uk.gov.hmrc" %% "play-ui" % "8.2.0-play-26",
     "uk.gov.hmrc" %% "play-language" % "3.4.0",
     typesafe %% "play-json" % "2.6.13",
     typesafe %% "play-json-joda" % "2.6.13",
@@ -51,7 +51,7 @@ private object AppDependencies {
         "org.pegdown" % "pegdown" % "1.6.0" % scope,
         "org.jsoup" % "jsoup" % "1.12.1" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-        "org.mockito" % "mockito-core" % "3.0.0" % scope,
+        "org.mockito" % "mockito-core" % "3.1.0" % scope,
         "com.github.fge" % "json-schema-validator" % jsonSchemaValidatorVersion % scope,
         "org.json" % "json" % jsonVersion % scope
       )
@@ -73,7 +73,7 @@ private object AppDependencies {
         "org.pegdown" % "pegdown" % "1.6.0" % scope,
         "org.jsoup" % "jsoup" % "1.12.1" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-        "org.mockito" % "mockito-core" % "3.0.0" % scope,
+        "org.mockito" % "mockito-core" % "3.1.0" % scope,
         "com.github.fge" % "json-schema-validator" % jsonSchemaValidatorVersion % scope,
         "org.json" % "json" % jsonVersion % scope,
         "com.github.tomakehurst" %  "wiremock" % wireMockVersion % scope,

--- a/test/iht/models/RegistrationTest.scala
+++ b/test/iht/models/RegistrationTest.scala
@@ -48,6 +48,18 @@ class RegistrationTest extends FakeIhtApp with MockitoSugar with StringHelper {
     }
    }
 
+  "ApplicantDetails" must {
+    "return a proper name when a first and second name are present" in {
+      val ad = CommonBuilder.buildApplicantDetails
+      ad.name mustBe ad.firstName.get + " " + ad.lastName.get
+    }
+
+    "return an empty string if first and second names are not present." in {
+      val ad = CommonBuilder.buildApplicantDetails copy(firstName = None, lastName = None)
+      ad.name mustBe " "
+    }
+  }
+
   "Deceased details" must {
     "respond correctly when isCompleted is called for completed object" in {
       val dd = CommonBuilder.buildDeceasedDetails
@@ -58,12 +70,19 @@ class RegistrationTest extends FakeIhtApp with MockitoSugar with StringHelper {
       dd.isCompleted mustBe false
     }
     "respond correctly when ninoFormatted is called" in {
-      val dd = CommonBuilder.buildDeceasedDetails
-      dd.ninoFormatted mustBe ninoFormat(dd.nino.getOrElse(""))
+      val dd = CommonBuilder.buildDeceasedDetails copy(nino = Some("a a 1 2 34 5 6c"))
+      dd.ninoFormatted mustBe Some("AA123456C")
     }
     "respond correctly when ninoFormatted is called with nino of None" in {
       val dd = CommonBuilder.buildDeceasedDetails copy(nino = None)
-      dd.ninoFormatted mustBe ""
+      dd.ninoFormatted mustBe None
+    }
+  }
+
+  "CoExecutor" must {
+    "respond correctly when ninoFormatted is called" in {
+      val coExec = CommonBuilder.buildCoExecutor copy(nino = "a a 1 2 34 5 6c")
+      coExec.ninoFormatted mustBe "AA123456C"
     }
   }
 }

--- a/test/iht/models/application/exemptions/PartnerExemptionTest.scala
+++ b/test/iht/models/application/exemptions/PartnerExemptionTest.scala
@@ -16,26 +16,30 @@
 
 package iht.models.application.exemptions
 
+import iht.FakeIhtApp
+import iht.config.AppConfig
 import iht.testhelpers.CommonBuilder
 import org.scalatest.mock.MockitoSugar
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 
-class PartnerExemptionTest extends UnitSpec with MockitoSugar{
+class PartnerExemptionTest extends FakeIhtApp with MockitoSugar {
+
+  implicit val mockAppConfig = app.injector.instanceOf[AppConfig]
 
   "isComplete" must {
 
     "return Some(true) when PartnerExemption is complete" in {
       val partnerExemption = CommonBuilder.buildPartnerExemption
 
-      partnerExemption.isComplete shouldBe Some(true)
+      partnerExemption.isComplete mustBe  Some(true)
     }
 
     "return Some(true) when AssetForDeceasedPartner is selected as No" in {
       val partnerExemption = CommonBuilder.buildPartnerExemption.copy(
         isAssetForDeceasedPartner = Some(false))
 
-      partnerExemption.isComplete shouldBe Some(true)
+      partnerExemption.isComplete mustBe  Some(true)
     }
 
     "return Some(false) when AssetForDeceasedPartner is selected as Yes and all other questions have not been answered" in {
@@ -49,17 +53,17 @@ class PartnerExemptionTest extends UnitSpec with MockitoSugar{
         totalAssets = None
       )
 
-      partnerExemption.isComplete shouldBe Some(false)
+      partnerExemption.isComplete mustBe  Some(false)
     }
 
     "return None when all the fields are None" in {
       val partnerExemption = CommonBuilder.buildPartnerExemption.copy(None, None, None ,None, None, None, None)
-      partnerExemption.isComplete shouldBe empty
+      partnerExemption.isComplete mustBe  empty
     }
 
     "return None when AssetForDeceasedPartner is None" in {
       val partnerExemption = CommonBuilder.buildPartnerExemption.copy(isAssetForDeceasedPartner = None)
-      partnerExemption.isComplete shouldBe empty
+      partnerExemption.isComplete mustBe  empty
     }
   }
 
@@ -72,14 +76,32 @@ class PartnerExemptionTest extends UnitSpec with MockitoSugar{
       val partnerExemption = CommonBuilder.buildPartnerExemption.copy(
         firstName = Some(firstName), lastName = Some(lastName))
 
-      partnerExemption.name shouldBe Some(firstName+" "+lastName)
+      partnerExemption.name mustBe  Some(firstName+" "+lastName)
     }
 
     "return None when first and last name are not entered" in {
       val partnerExemption = CommonBuilder.buildPartnerExemption.copy(
         firstName = None, lastName = None)
 
-      partnerExemption.name shouldBe empty
+      partnerExemption.name mustBe  empty
+    }
+  }
+
+  "ninoFormatted" must {
+
+    "return a properly formatted Nino as an option" in {
+      val nino = "aa 12 34 56 b"
+
+      val partnerExemption = CommonBuilder.buildPartnerExemption.copy(
+        nino = Some(nino))
+
+      partnerExemption.ninoFormatted mustBe  Some("AA123456B")
+    }
+
+    "return None when nino is not entered" in {
+      val partnerExemption = CommonBuilder.buildPartnerExemption.copy(nino = None)
+
+      partnerExemption.ninoFormatted mustBe  None
     }
   }
 }


### PR DESCRIPTION
# DL-2395 - Nino formatting

**Bug fix**

This fix ensures that ninos that are entered by users are stripped of whitespace and converted to uppercase before they are stored.

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

- Note: I could not update play-language to 4.1.0 as part of this PR. Will raise a separate story to do this across all relevant services.

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
