### PR TITLE
[DL-1113] Modified CustomLanguageUtilsTest to be independent of timezone

### DIFF
--- a/test/iht/utils/CustomLanguageUtilsTest.scala
+++ b/test/iht/utils/CustomLanguageUtilsTest.scala
@@ -57,7 +57,7 @@ class CustomLanguageUtilsTest extends ViewTestHelper {
 
   "CustomLanguageUtils.Dates#formatEasyReadingTimestamp" must {
     "convert an optional LocalDate object to a date string (h:mmaa, EEEE d MMMM yyyy)" in {
-      val epochDateTime = epoch.toDateTime(LocalTime.MIDNIGHT)
+      val epochDateTime = DateTime.parse("1970-01-01T00:00")
 
       Dates.formatEasyReadingTimestamp(Some(epochDateTime), "not-valid") mustBe "12:00am, Thursday 1 January 1970"
     }
@@ -78,10 +78,8 @@ class CustomLanguageUtilsTest extends ViewTestHelper {
 
   "CustomLanguageUtils.Dates#formatDays" must {
     "convert an int to a string appended by 'days'" in {
-      var numberOfDays = 3
-      Dates.formatDays(numberOfDays) mustBe s"$numberOfDays days"
-      numberOfDays = 1
-      Dates.formatDays(numberOfDays) mustBe s"$numberOfDays day"
+      Dates.formatDays(3) mustBe "3 days"
+      Dates.formatDays(1) mustBe "1 day"
 
     }
   }


### PR DESCRIPTION
[DL-1113] - Raised test coverage for IHT Front-end

Modified CustomLanguageUtilsTest to be independent of timezone

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer - Ben*
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
