### PR TITLE
DL-2242 - IHT - MockitoSugar deprecation issue in Unit Tests

### DIFF
--- a/it/controllers/DeclarationControllerSpec.scala
+++ b/it/controllers/DeclarationControllerSpec.scala
@@ -9,7 +9,7 @@ import iht.forms.ApplicationForms.declarationForm
 import iht.metrics.IhtMetrics
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.Form
 import play.api.libs.json.Json
 import play.api.mvc.{AnyContentAsFormUrlEncoded, MessagesControllerComponents, RequestHeader}

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -51,7 +51,7 @@ private object AppDependencies {
         "org.pegdown" % "pegdown" % "1.6.0" % scope,
         "org.jsoup" % "jsoup" % "1.12.1" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-        "org.mockito" % "mockito-core" % "3.1.0" % scope,
+        "org.mockito" % "mockito-core" % "3.2.0" % scope,
         "com.github.fge" % "json-schema-validator" % jsonSchemaValidatorVersion % scope,
         "org.json" % "json" % jsonVersion % scope
       )
@@ -73,7 +73,7 @@ private object AppDependencies {
         "org.pegdown" % "pegdown" % "1.6.0" % scope,
         "org.jsoup" % "jsoup" % "1.12.1" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-        "org.mockito" % "mockito-core" % "3.1.0" % scope,
+        "org.mockito" % "mockito-core" % "3.2.0" % scope,
         "com.github.fge" % "json-schema-validator" % jsonSchemaValidatorVersion % scope,
         "org.json" % "json" % jsonVersion % scope,
         "com.github.tomakehurst" %  "wiremock" % wireMockVersion % scope,

--- a/test/iht/config/IhtPropertiesReaderTest.scala
+++ b/test/iht/config/IhtPropertiesReaderTest.scala
@@ -16,7 +16,7 @@
 
 package iht.config
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.OneAppPerTest
 import play.api.Environment
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/iht/controllers/registration/RegistrationControllerTest.scala
+++ b/test/iht/controllers/registration/RegistrationControllerTest.scala
@@ -25,7 +25,7 @@ import iht.{FakeIhtApp, TestUtils}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{I18nSupport, Lang, MessagesApi}
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, MessagesControllerComponents}
 import play.api.test.{FakeHeaders, FakeRequest}

--- a/test/iht/forms/FormTestHelper.scala
+++ b/test/iht/forms/FormTestHelper.scala
@@ -20,7 +20,7 @@ import iht.config.AppConfig
 import iht.models.UkAddress
 import iht.testhelpers.CommonBuilder
 import iht.{FakeIhtApp, TestUtils}
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.{Form, FormError}
 import play.api.i18n.MessagesApi
 import play.api.libs.json.JsValue

--- a/test/iht/models/RegistrationTest.scala
+++ b/test/iht/models/RegistrationTest.scala
@@ -20,7 +20,7 @@ import iht.FakeIhtApp
 import iht.config.AppConfig
 import iht.testhelpers.CommonBuilder
 import iht.utils.{StringHelper, StringHelperFixture}
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class RegistrationTest extends FakeIhtApp with MockitoSugar with StringHelper {
 

--- a/test/iht/models/application/ApplicationDetailsTest.scala
+++ b/test/iht/models/application/ApplicationDetailsTest.scala
@@ -23,7 +23,7 @@ import iht.models.application.exemptions.BasicExemptionElement
 import iht.models.application.tnrb.WidowCheck
 import iht.testhelpers.{AssetsWithAllSectionsSetToNoBuilder, CommonBuilder, TestHelper}
 import org.joda.time.LocalDate
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.mvc.MessagesControllerComponents
 

--- a/test/iht/models/application/assets/AllAssetsTest.scala
+++ b/test/iht/models/application/assets/AllAssetsTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.assets
 
 import iht.testhelpers.{AssetsWithAllSectionsSetToNoBuilder, CommonBuilder}
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/assets/HeldInTrustTest.scala
+++ b/test/iht/models/application/assets/HeldInTrustTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.assets
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/assets/InsurancePolicyTest.scala
+++ b/test/iht/models/application/assets/InsurancePolicyTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.assets
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/assets/PrivatePensionTest.scala
+++ b/test/iht/models/application/assets/PrivatePensionTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.assets
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/assets/PropertyTest.scala
+++ b/test/iht/models/application/assets/PropertyTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.assets
 
 import iht.testhelpers.{TestHelper, CommonBuilder}
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/assets/StockAndShareTest.scala
+++ b/test/iht/models/application/assets/StockAndShareTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.assets
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/basicElements/BasicEstateElementTest.scala
+++ b/test/iht/models/application/basicElements/BasicEstateElementTest.scala
@@ -17,7 +17,7 @@
 package iht.models.basicElements
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/basicElements/EstateElementTest.scala
+++ b/test/iht/models/application/basicElements/EstateElementTest.scala
@@ -16,7 +16,7 @@
 
 package iht.models.application.basicElements
 
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 class EstateElementTest extends UnitSpec with MockitoSugar{

--- a/test/iht/models/application/basicElements/ShareableBasicEstateElementTest.scala
+++ b/test/iht/models/application/basicElements/ShareableBasicEstateElementTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.basicElements
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/debts/AllLiabilitiesTest.scala
+++ b/test/iht/models/application/debts/AllLiabilitiesTest.scala
@@ -19,7 +19,7 @@ package iht.models.application.debts
 import iht.FakeIhtApp
 import iht.config.AppConfig
 import iht.testhelpers.{AssetsWithAllSectionsSetToNoBuilder, CommonBuilder, TestHelper}
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 class AllLiabilitiesTest extends UnitSpec with MockitoSugar {

--- a/test/iht/models/application/debts/BasicEstateElementLiabilitiesTest.scala
+++ b/test/iht/models/application/debts/BasicEstateElementLiabilitiesTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.debts
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/debts/MortgageEstateElementTest.scala
+++ b/test/iht/models/application/debts/MortgageEstateElementTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.debts
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 class MortgageEstateElementTest extends UnitSpec with MockitoSugar{

--- a/test/iht/models/application/debts/MortgageTest.scala
+++ b/test/iht/models/application/debts/MortgageTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.debts
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/exemptions/AllExemptionsTest.scala
+++ b/test/iht/models/application/exemptions/AllExemptionsTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.exemptions
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 class AllExemptionsTest extends UnitSpec with MockitoSugar {

--- a/test/iht/models/application/exemptions/CharityTest.scala
+++ b/test/iht/models/application/exemptions/CharityTest.scala
@@ -18,7 +18,7 @@ package iht.models.application.exemptions
 
 import iht.FakeIhtApp
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Lang, Messages, MessagesApi}
 
 class CharityTest extends FakeIhtApp with MockitoSugar {

--- a/test/iht/models/application/exemptions/PartnerExemptionTest.scala
+++ b/test/iht/models/application/exemptions/PartnerExemptionTest.scala
@@ -19,7 +19,7 @@ package iht.models.application.exemptions
 import iht.FakeIhtApp
 import iht.config.AppConfig
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 

--- a/test/iht/models/application/exemptions/QualifyingBodyTest.scala
+++ b/test/iht/models/application/exemptions/QualifyingBodyTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.exemptions
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/gifts/AllGiftsTest.scala
+++ b/test/iht/models/application/gifts/AllGiftsTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.gifts
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/application/tnrb/TnrbEligibiltyModelTest.scala
+++ b/test/iht/models/application/tnrb/TnrbEligibiltyModelTest.scala
@@ -17,7 +17,7 @@
 package iht.models.application.tnrb
 
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 

--- a/test/iht/models/des/EventRegistrationTest.scala
+++ b/test/iht/models/des/EventRegistrationTest.scala
@@ -19,7 +19,7 @@ package models.des
 import iht.FakeIhtApp
 import iht.config.AppConfig
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class EventRegistrationTest extends FakeIhtApp with MockitoSugar {
   implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]

--- a/test/iht/models/des/IHTReturnTest.scala
+++ b/test/iht/models/des/IHTReturnTest.scala
@@ -22,7 +22,7 @@ import iht.models.des.ihtReturn.IHTReturn
 import iht.testhelpers.CommonBuilder
 import iht.testhelpers.IHTReturnTestHelper._
 import org.joda.time.LocalDate
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class IHTReturnTest extends FakeIhtApp with MockitoSugar {
   implicit val mockAppConfig: AppConfig = app.injector.instanceOf[AppConfig]

--- a/test/iht/models/enums/IdentityVerificationResultTest.scala
+++ b/test/iht/models/enums/IdentityVerificationResultTest.scala
@@ -18,7 +18,7 @@ package iht.models.enums
 
 import iht.FakeIhtApp
 import iht.models.enums.IdentityVerificationResult.IdentityVerificationResult
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 import play.api.libs.json._
 

--- a/test/iht/utils/AddressHelperTest.scala
+++ b/test/iht/utils/AddressHelperTest.scala
@@ -19,7 +19,7 @@ package iht.utils
 import iht.FakeIhtApp
 import iht.config.AppConfig
 import iht.testhelpers._
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class AddressHelperTest extends FakeIhtApp with MockitoSugar {
   implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]

--- a/test/iht/utils/ApplicantHelperTest.scala
+++ b/test/iht/utils/ApplicantHelperTest.scala
@@ -19,7 +19,7 @@ package iht.utils
 import iht.FakeIhtApp
 import iht.config.AppConfig
 import iht.testhelpers._
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 
 class ApplicantHelperTest extends FakeIhtApp with MockitoSugar {

--- a/test/iht/utils/ApplicationKickoutNonSummaryHelperTest.scala
+++ b/test/iht/utils/ApplicationKickoutNonSummaryHelperTest.scala
@@ -24,7 +24,7 @@ import iht.models.application.basicElements.ShareableBasicEstateElement
 import iht.models.application.exemptions.BasicExemptionElement
 import iht.testhelpers.CommonBuilder
 import iht.testhelpers.CommonBuilder._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 class ApplicationKickoutNonSummaryHelperTest extends FakeIhtApp with MockitoSugar with ApplicationKickOutNonSummaryHelper {

--- a/test/iht/utils/CommonHelperTest.scala
+++ b/test/iht/utils/CommonHelperTest.scala
@@ -22,7 +22,7 @@ import iht.models.{DeceasedDetails, RegistrationDetails}
 import iht.models.application.ApplicationDetails
 import iht.testhelpers.CommonBuilder
 import iht.testhelpers.CommonBuilder._
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/iht/utils/DateHelperTest.scala
+++ b/test/iht/utils/DateHelperTest.scala
@@ -19,7 +19,7 @@ package iht.utils
 import iht.FakeIhtApp
 import iht.config.AppConfig
 import org.joda.time.LocalDate
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class DateHelperTest extends FakeIhtApp with MockitoSugar {
 

--- a/test/iht/utils/DeceasedInfoHelperTest.scala
+++ b/test/iht/utils/DeceasedInfoHelperTest.scala
@@ -21,7 +21,7 @@ import iht.config.AppConfig
 import iht.models.DeceasedDateOfDeath
 import iht.testhelpers._
 import org.joda.time.LocalDate
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{I18nSupport, Lang, MessagesApi}
 import play.api.mvc.MessagesControllerComponents
 

--- a/test/iht/utils/ExemptionsGuidanceHelperTest.scala
+++ b/test/iht/utils/ExemptionsGuidanceHelperTest.scala
@@ -23,7 +23,7 @@ import iht.testhelpers.{CommonBuilder, MockObjectBuilder}
 import iht.{FakeIhtApp, TestUtils}
 import org.mockito.ArgumentMatchers.same
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Call
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import play.api.test.{FakeHeaders, FakeRequest}

--- a/test/iht/utils/FieldMappingsTest.scala
+++ b/test/iht/utils/FieldMappingsTest.scala
@@ -19,7 +19,7 @@ package iht.utils
 import iht.FakeIhtApp
 import iht.config.AppConfig
 import iht.constants.FieldMappings
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Lang, MessagesApi}
 
 class FieldMappingsTest extends FakeIhtApp with MockitoSugar {

--- a/test/iht/utils/FormValidatorTest.scala
+++ b/test/iht/utils/FormValidatorTest.scala
@@ -23,7 +23,7 @@ import iht.forms.FormTestHelper
 import iht.testhelpers.{CommonBuilder, NinoBuilder, TestHelper}
 import iht.utils.IhtFormValidator._
 import org.joda.time.LocalDate
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.{FieldMapping, Form, FormError}
 import play.api.i18n.MessagesApi
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/iht/utils/GiftsHelperTest.scala
+++ b/test/iht/utils/GiftsHelperTest.scala
@@ -21,7 +21,7 @@ import iht.config.AppConfig
 import iht.models.application.gifts.PreviousYearsGifts
 import iht.testhelpers.CommonBuilder
 import org.joda.time.LocalDate
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class GiftsHelperTest extends FakeIhtApp with MockitoSugar {
 

--- a/test/iht/utils/IhtFormValidatorTest.scala
+++ b/test/iht/utils/IhtFormValidatorTest.scala
@@ -22,7 +22,7 @@ import iht.connector.CachingConnector
 import iht.models.RegistrationDetails
 import iht.testhelpers.{CommonBuilder, NinoBuilder}
 import iht.utils.IhtFormValidator._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.data.format.Formatter
 import play.api.data.{FieldMapping, FormError}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/iht/utils/MessagesHelperTest.scala
+++ b/test/iht/utils/MessagesHelperTest.scala
@@ -20,7 +20,7 @@ import iht.FakeIhtApp
 import iht.views.helpers.MessagesHelper
 import org.mockito.Mockito
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{I18nSupport, Lang, Messages, MessagesApi}
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.FakeRequest

--- a/test/iht/utils/OverviewHelperTest.scala
+++ b/test/iht/utils/OverviewHelperTest.scala
@@ -21,7 +21,7 @@ import iht.constants.Constants
 import iht.models.application.assets.{AllAssets, InsurancePolicy}
 import iht.models.application.debts.{AllLiabilities, BasicEstateElementLiabilities}
 import iht.testhelpers._
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Lang, Messages}
 import play.api.mvc.MessagesControllerComponents
 

--- a/test/iht/utils/PropertyAndMortgageHelperTest.scala
+++ b/test/iht/utils/PropertyAndMortgageHelperTest.scala
@@ -21,7 +21,7 @@ import iht.config.AppConfig
 import iht.models.application.assets.Properties
 import iht.models.application.debts.{Mortgage, MortgageEstateElement}
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Results
 
 class PropertyAndMortgageHelperTest extends FakeIhtApp with MockitoSugar with PropertyAndMortgageHelper {

--- a/test/iht/utils/RegistrationDetailsHelperTest.scala
+++ b/test/iht/utils/RegistrationDetailsHelperTest.scala
@@ -22,7 +22,7 @@ import iht.models.RegistrationDetails
 import iht.models.application.ApplicationDetails
 import iht.models.application.exemptions.BasicExemptionElement
 import iht.testhelpers._
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest
 
 import scala.collection.immutable.ListMap

--- a/test/iht/utils/SessionHelperTest.scala
+++ b/test/iht/utils/SessionHelperTest.scala
@@ -20,7 +20,7 @@ import iht.FakeIhtApp
 import iht.config.AppConfig
 import iht.constants.Constants
 import iht.testhelpers._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Session
 import play.api.test.FakeRequest
 

--- a/test/iht/utils/StringHelperTest.scala
+++ b/test/iht/utils/StringHelperTest.scala
@@ -19,7 +19,7 @@ package iht.utils
 import iht.FakeIhtApp
 import iht.config.AppConfig
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.MessagesApi
 
 class StringHelperTest extends FakeIhtApp with MockitoSugar with StringHelper {

--- a/test/iht/utils/SubmissionDeadlineHelperTest.scala
+++ b/test/iht/utils/SubmissionDeadlineHelperTest.scala
@@ -25,7 +25,7 @@ import org.joda.time.LocalDate
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future

--- a/test/iht/utils/UtilPackageTest.scala
+++ b/test/iht/utils/UtilPackageTest.scala
@@ -17,7 +17,7 @@
 package iht.utils
 
 import iht.FakeIhtApp
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 
 /**

--- a/test/iht/utils/pdf/FopURIResolverTest.scala
+++ b/test/iht/utils/pdf/FopURIResolverTest.scala
@@ -20,7 +20,7 @@ import java.net.URI
 
 import iht.FakeIhtApp
 import org.apache.xmlgraphics.io.Resource
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.Environment
 
 /**

--- a/test/iht/utils/pdf/StylesheetResolverTest.scala
+++ b/test/iht/utils/pdf/StylesheetResolverTest.scala
@@ -18,7 +18,7 @@ package iht.utils.pdf
 
 import iht.FakeIhtApp
 import javax.xml.transform.stream.StreamSource
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.Environment
 
 /**

--- a/test/iht/utils/pdf/XSLScalaBridgeTest.scala
+++ b/test/iht/utils/pdf/XSLScalaBridgeTest.scala
@@ -18,7 +18,7 @@ package iht.utils.pdf
 
 import iht.FakeIhtApp
 import iht.testhelpers.CommonBuilder
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{I18nSupport, Lang, Messages, MessagesApi}
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/iht/utils/tnrb/TnrbHelperTest.scala
+++ b/test/iht/utils/tnrb/TnrbHelperTest.scala
@@ -23,7 +23,7 @@ import iht.controllers.application.tnrb.routes
 import iht.testhelpers.TestHelper._
 import iht.testhelpers.{ContentChecker, _}
 import org.joda.time.LocalDate
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._

--- a/test/iht/utils/xml/ModelToXMLSourceTest.scala
+++ b/test/iht/utils/xml/ModelToXMLSourceTest.scala
@@ -22,7 +22,7 @@ import iht.resources.{IhtReturn, RegistrationDetailsReturnBuilder}
 import iht.testhelpers.CommonBuilder
 import iht.testhelpers.IHTReturnTestHelper._
 import org.joda.time.LocalDate
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.xml.XML
 

--- a/test/iht/viewmodels/application/overview/AssetsAndGiftsSectionViewModelTest.scala
+++ b/test/iht/viewmodels/application/overview/AssetsAndGiftsSectionViewModelTest.scala
@@ -22,7 +22,7 @@ import iht.testhelpers.CommonBuilder
 import iht.testhelpers.TestHelper._
 import iht.{FakeIhtApp, TestUtils}
 import org.scalatest.BeforeAndAfter
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import iht.config.AppConfig
 import play.api.i18n.{Lang, Messages, MessagesApi}

--- a/test/iht/viewmodels/application/overview/DeclarationSectionViewModelTest.scala
+++ b/test/iht/viewmodels/application/overview/DeclarationSectionViewModelTest.scala
@@ -22,7 +22,7 @@ import iht.testhelpers.{CommonBuilder, TestHelper}
 import iht.{FakeIhtApp, TestUtils}
 import org.joda.time.LocalDate
 import org.scalatest.BeforeAndAfter
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
 import iht.testhelpers.TestHelper._
 import play.api.i18n.{Lang, Messages, MessagesApi}

--- a/test/iht/viewmodels/application/overview/OtherDetailsSectionViewModelTest.scala
+++ b/test/iht/viewmodels/application/overview/OtherDetailsSectionViewModelTest.scala
@@ -23,7 +23,7 @@ import iht.testhelpers.CommonBuilder
 import iht.testhelpers.TestHelper._
 import iht.{FakeIhtApp, TestUtils}
 import org.scalatest.BeforeAndAfter
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.mvc.MessagesControllerComponents
 

--- a/test/iht/viewmodels/application/overview/ReducingEstateValueSectionViewModelTest.scala
+++ b/test/iht/viewmodels/application/overview/ReducingEstateValueSectionViewModelTest.scala
@@ -22,7 +22,7 @@ import iht.models.application.exemptions._
 import iht.testhelpers.CommonBuilder
 import iht.{FakeIhtApp, TestUtils}
 import org.scalatest.BeforeAndAfter
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Lang, Messages, MessagesApi}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import iht.config.AppConfig

--- a/test/iht/viewmodels/application/overview/ThresholdSectionViewModelTest.scala
+++ b/test/iht/viewmodels/application/overview/ThresholdSectionViewModelTest.scala
@@ -23,7 +23,7 @@ import iht.testhelpers.TestHelper._
 import iht.{FakeIhtApp, TestUtils}
 import org.joda.time.LocalDate
 import org.scalatest.BeforeAndAfter
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{I18nSupport, Lang, Messages, MessagesApi}
 import play.api.mvc.MessagesControllerComponents
 

--- a/test/iht/views/ViewTestHelper.scala
+++ b/test/iht/views/ViewTestHelper.scala
@@ -25,7 +25,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.safety.Whitelist
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterEach}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.play.partials.FormPartialRetriever


### PR DESCRIPTION
# DL-2242 - IHT - MockitoSugar deprecation issue in Unit Tests

Replaced imports of ```org.scalatest.mockito.MockitoSugar``` and ```org.scalatest.mock.MockitoSugar``` with ```org.scalatestplus.mockito.MockitoSugar```

## Checklist

*Reviewee* (Stephen)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
