### PR TITLE
DL-2182 - java.lang.NumberFormatException: null

### DIFF
--- a/app/iht/forms/validators/Currency.scala
+++ b/app/iht/forms/validators/Currency.scala
@@ -22,7 +22,7 @@ import play.api.data.FormError
   * Created by grant on 14/12/16.
   */
 trait Currency {
-  protected lazy val moneyFormatSimple = """^(\d*+([.]\d{1,2})?)$""".r
+  protected lazy val moneyFormatSimple = """^(\d*([.]\d{1,2})?)$""".r
   protected lazy val stringWithSpacesRegEx = "\\s+".r
   protected lazy val valueWithCommaFormatRegEx =
                               """(^(\d*)(\.\d{0,2})?$)|(^(\d{1,3},(\d{3},)*\d{3}(\.\d{1,2})?|\d{1,3}(\.\d{1,2})?)$)""".r
@@ -30,7 +30,7 @@ trait Currency {
   protected lazy val isInvalidPence: String => Boolean = s =>
     s.count(_ == '.') match {
       case numberDecimalPoints if numberDecimalPoints > 1 => true
-      case numberDecimalPoints if numberDecimalPoints == 1 && s.substring(s.indexOf(".") + 1).length > 2 => true
+      case numberDecimalPoints if numberDecimalPoints == 1 && s.substring(s.indexOf(".") + 1).trim().length > 2 => true
       case _ => false
     }
   protected lazy val isInvalidNumericCharacters: String => Boolean = s => s.exists(c => c != '.' && !c.isDigit && c != ' ' && c!=',')

--- a/app/iht/utils/FormValidator.scala
+++ b/app/iht/utils/FormValidator.scala
@@ -34,7 +34,7 @@ trait FormValidator {
   protected val postCodeFormat = "(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))"
   // scalastyle:on line.size.limit
   protected val phoneNoFormat = "^[A-Z0-9 \\)\\/\\(\\-\\*#]{1,27}$"
-  protected lazy val moneyFormatSimple = """^(\d{1,10}+([.]\d{1,2})?)$""".r
+  protected lazy val moneyFormatSimple = """^(\d{0,10}([.]\d{1,2})?)$""".r
 
   //lazy val nameAndAddressRegex = """^[A-Za-z0-9,. \(\)\&\-']*$""".r
   lazy val nameAndAddressRegex = """^.*$""".r

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -46,7 +46,7 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*\$]]></parameter>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>

--- a/test/iht/forms/validators/MandatoryCurrencyTest.scala
+++ b/test/iht/forms/validators/MandatoryCurrencyTest.scala
@@ -87,6 +87,21 @@ class MandatoryCurrencyTest extends FakeIhtApp {
       mandatoryCurrency.bind(Map("" -> "2,000.00")) mustBe Right(Some(2000))
     }
 
+    "give no error if the value has spaces after the decimal point" in {
+      mandatoryCurrency.bind(Map("" -> "1.00 ")) mustBe Right(Some(1.00))
+      mandatoryCurrency.bind(Map("" -> "1. ")) mustBe Right(Some(1.00))
+    }
+
+    "give no error if the value has spaces before the decimal point" in {
+      mandatoryCurrency.bind(Map("" -> " 2.30")) mustBe Right(Some(2.30))
+      mandatoryCurrency.bind(Map("" -> " 2.")) mustBe Right(Some(2.00))
+    }
+
+    "give no error if the value has spaces before and after the decimal point" in {
+      mandatoryCurrency.bind(Map("" -> " 6.10 ")) mustBe Right(Some(6.10))
+      mandatoryCurrency.bind(Map("" -> " 6. ")) mustBe Right(Some(6.00))
+    }
+
     "give error if the value has comma at wrong position" in {
       mandatoryCurrency.bind(Map("" -> "220,00.00")) mustBe Left(List(FormError("", "hasCommaAtInvalidPosition")))
       mandatoryCurrency.bind(Map("" -> "2,00.00")) mustBe Left(List(FormError("", "hasCommaAtInvalidPosition")))

--- a/test/iht/utils/FormValidatorTest.scala
+++ b/test/iht/utils/FormValidatorTest.scala
@@ -79,6 +79,11 @@ class FormValidatorTest extends FormTestHelper with FakeIhtApp {
     "Report correctly for invalid numeric value length>10" in {
       optionalCurrencyWithoutFieldName.bind(Map("" -> "11111111111111111111")) mustBe Left(List(FormError("", "error.currencyValue.length")))
     }
+
+    "clean and parse a decimal value missing its left side" in {
+      cleanMoneyString(".73") mustBe ".73"
+    }
+
  }
 
   "mandatoryPhoneNumberFormatter" must {

--- a/test/iht/utils/IhtFormValidatorTest.scala
+++ b/test/iht/utils/IhtFormValidatorTest.scala
@@ -82,6 +82,23 @@ class IhtFormValidatorTest extends FakeIhtApp with MockitoSugar {
       val result = fv.bind("", Map("value" -> "12000", "ex" -> "15000"))
       result mustBe Left(List(FormError("ex", "error.giftsDetails.exceedsGivenAway")))
     }
+
+    "display error if value < exemptions, where the value is empty and the exemptions is a decimal number missing its left side" in {
+      val result = fv.bind("", Map("value" -> "", "ex" -> ".01"))
+      result mustBe Left(List(FormError("value", "error.giftsDetails.noValue")))
+    }
+
+    "display error if value < exemptions, where both the value and exemptions are decimal numbers missing their left side" in {
+      val result = fv.bind("", Map("value" -> ".63", "ex" -> ".98"))
+      result mustBe Left(List(FormError("ex", "error.giftsDetails.exceedsGivenAway")))
+    }
+
+    "trim and process values/exemptionValues containing whitespace" in {
+      val valueWithWhiteSpace = " 100 "
+      val exemptionValueWithWhiteSpace = " 20 "
+      val result = fv.bind("value", Map("value" -> valueWithWhiteSpace, "ex" -> exemptionValueWithWhiteSpace))
+      result mustBe Right(Some(valueWithWhiteSpace))
+    }
   }
 
   "nino" should {


### PR DESCRIPTION
# DL-2182 - BigDecimal failed to be created from a number

Removed bug that prevented fields appended/preceded with spaces to be processed. Also changed validation to accept spaces after a decimal number. Amended inaccurate regex that allowed exemption values to be larger than gift values.

## Checklist

*Reviewee* (Stephen)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
