### PR TITLE
DL-2804 - Lowered play-json version to 2.6.13

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,7 +11,7 @@ object AppDependencies {
   private val wireMockVersion = "2.26.2"
   private val jsoupVersion = "1.13.1"
   private val mockitoVersion = "3.3.1"
-  private val playJsonVersion = "2.8.1"
+  private val playJsonVersion = "2.6.13"
 
   private val typesafe = "com.typesafe.play"
 


### PR DESCRIPTION
# DL-2804 - Lowered play-json version to 2.6.13

I increased the `play-json-joda `version for the previous PR without running the UI tests, causing Jenkins to fail. This PR is to lower them back to `2.6.13`.

## Checklist

*Reviewee* (Replace with your name)
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
