### PR TITLE
DL-3715 Change INFO to WARN for auth failures

### DIFF
--- a/app/iht/controllers/auth/IhtBaseController.scala
+++ b/app/iht/controllers/auth/IhtBaseController.scala
@@ -46,10 +46,10 @@ trait IhtBaseController extends FrontendController with AuthorisedFunctions with
 
   private def handleAuthErrors(implicit request: Request[_]): PartialFunction[Throwable, Result] = {
     case e: InsufficientConfidenceLevel =>
-      Logger.info(s"Insufficient confidence level user attempting to access ${request.path} redirecting to IV uplift : ${e.getMessage}")
+      Logger.warn(s"Insufficient confidence level user attempting to access ${request.path} redirecting to IV uplift : ${e.getMessage}")
       redirectToIV
     case e: AuthorisationException =>
-      Logger.info(s"unauthenticated user attempting to access ${request.path} redirecting to login : ${e.getMessage}")
+      Logger.warn(s"unauthenticated user attempting to access ${request.path} redirecting to login : ${e.getMessage}")
       redirectToLogin
   }
 


### PR DESCRIPTION
# DL-3715 Change INFO to WARN for auth failures

**Bug fix**

Changed the auth failures to log at WARN level rather than INFO level as we don't get INFO level in production and switching it on produces too much.

## Checklist

*Reviewee* (@grahampaulcook )
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
