### PR TITLE
DL-4657 fixed moving get help link in firefox

### DIFF
--- a/app/assets/stylesheets/partials/_shame.scss
+++ b/app/assets/stylesheets/partials/_shame.scss
@@ -15,6 +15,12 @@
   }
 }
 
+@-moz-document url-prefix(){
+    details summary{
+        float: left;
+    }
+}
+
 
 // remove external link indicator following its removal from template
 a[rel="external"]:after {


### PR DESCRIPTION
# DL-4657 fixed moving get help link in firefox

**Bug fix

Get help link was being moved to the right when clicked on, on the Firefox browser. It should remain in the same place.

## Checklist

*Reviewee* (Ahmad)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
