### PR TITLE
DL-5108 Post submission PDF address bug fix

### DIFF
--- a/app/iht/models/des/ihtReturn/Asset.scala
+++ b/app/iht/models/des/ihtReturn/Asset.scala
@@ -16,6 +16,7 @@
 
 package iht.models.des.ihtReturn
 
+import models.des.Address
 import play.api.libs.json.Json
 
 case class Asset(
@@ -28,7 +29,7 @@ case class Asset(
                   devolutions: Option[Set[Devolution]] = None,
                   liabilities: Option[Set[Liability]] = None,
                   // Property asset
-                  propertyAddress: Option[AddressOrOtherLandLocation] = None,
+                  propertyAddress: Option[Address] = None,
                   tenure: Option[String] = None, tenancyType: Option[String] = None,
                   yearsLeftOnLease: Option[Int] = None,
                   yearsLeftOntenancyAgreement: Option[Int] = None,

--- a/app/iht/utils/pdf/PDFAssetHelper.scala
+++ b/app/iht/utils/pdf/PDFAssetHelper.scala
@@ -16,7 +16,7 @@
 
 package iht.utils.pdf
 
-import iht.models.des.ihtReturn.{AddressOrOtherLandLocation, Asset}
+import iht.models.des.ihtReturn.Asset
 
 object PDFAssetHelper {
   val blankBigDecimalValue = None //Some(BigDecimal(0))
@@ -210,11 +210,9 @@ object PDFAssetHelper {
   }
 
   private def buildAssetsPropertiesDeceasedsHome = {
-    val addressOrOtherLandLocation = AddressOrOtherLandLocation(
-      address = Some(models.des.Address(addressLine1 = "addr1", addressLine2 = "addr2",
+    val address = models.des.Address(addressLine1 = "addr1", addressLine2 = "addr2",
         addressLine3 = None, addressLine4 = None,
-        postalCode = DefaultPostCode, countryCode = "GB"))
-    )
+        postalCode = DefaultPostCode, countryCode = "GB")
 
     Asset(
       // General asset
@@ -227,7 +225,7 @@ object PDFAssetHelper {
       //      liabilities= None,
 
       // Property asset
-      propertyAddress = Some(addressOrOtherLandLocation),
+      propertyAddress = Some(address),
       tenure = Some("Freehold"), tenancyType = Some("Vacant Possession"),
       yearsLeftOnLease = Some(0),
       yearsLeftOntenancyAgreement = Some(0)

--- a/app/iht/utils/pdf/PdfHelper.scala
+++ b/app/iht/utils/pdf/PdfHelper.scala
@@ -291,7 +291,7 @@ trait PdfHelper {
   }
 
   private def propertyFromAsset(asset: Asset, nextId:Option[String]): Property = {
-    val optionUkAddress = asset.propertyAddress.flatMap(_.address).map { addr =>
+    val optionUkAddress = asset.propertyAddress.map { addr =>
       UkAddress(addr.addressLine1, addr.addressLine2, addr.addressLine3, addr.addressLine4, addr.postalCode, addr.countryCode)
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,7 @@ lazy val appDependencies: Seq[ModuleID] = AppDependencies()
 lazy val plugins : Seq[Plugins] = Seq(
   play.sbt.PlayScala,
   SbtAutoBuildPlugin,
-  SbtGitVersioning,
-  SbtDistributablesPlugin,
-  SbtArtifactory
+  SbtDistributablesPlugin
 )
 lazy val playSettings : Seq[Setting[_]] = Seq.empty
 
@@ -54,8 +52,8 @@ lazy val microservice = Project(appName, file("."))
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
   .settings(integrationTestSettings())
-  .settings(resolvers ++= Seq(Resolver.bintrayRepo("hmrc", "releases"), Resolver.jcenterRepo))
   .settings(majorVersion := 6)
+  .settings(isPublicArtefact := true)
   // ***************
   // Use the silencer plugin to suppress warnings from unused imports in compiled twirl templates
   scalacOptions += "-P:silencer:pathFilters=views;routes;--feature"

--- a/build.sbt
+++ b/build.sbt
@@ -40,8 +40,7 @@ lazy val microservice = Project(appName, file("."))
     scalaVersion := "2.12.12",
     libraryDependencies ++= appDependencies,
     fork in Test := false,
-    retrieveManaged := true,
-    evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false)
+    retrieveManaged := true
   )
   .settings(
     Concat.groups := Seq(

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -10,7 +10,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>%green(%date{ISO8601}) %gray(level=)[%highlight(%level)] %gray(message=[%yellow(%message)])  %gray(logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}]) %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
     </appender>
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,16 +1,9 @@
-resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
-resolvers += "SBT Releases" at "https://dl.bintray.com/sbt/sbt-plugin-releases"
-resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
-resolvers += "scoverage-bintray" at "https://dl.bintray.com/sksamuel/sbt-plugins/"
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.15.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.15.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
 

--- a/test/iht/testhelpers/IHTReturnTestHelper.scala
+++ b/test/iht/testhelpers/IHTReturnTestHelper.scala
@@ -485,11 +485,9 @@ object IHTReturnTestHelper {
   }
 
   def buildAssetsPropertiesDeceasedsHome = {
-    val addressOrOtherLandLocation = AddressOrOtherLandLocation(
-      address = Some(models.des.Address(addressLine1= "addr1", addressLine2= "addr2",
+    val address = models.des.Address(addressLine1= "addr1", addressLine2= "addr2",
         addressLine3= None, addressLine4= None,
-        postalCode= CommonBuilder.DefaultPostCode, countryCode= "GB"))
-    )
+        postalCode= CommonBuilder.DefaultPostCode, countryCode= "GB")
 
     val liability1 = Liability(
       liabilityType=Some("Mortgage"),
@@ -508,7 +506,7 @@ object IHTReturnTestHelper {
       //      liabilities= None,
 
       // Property asset
-      propertyAddress= Some(addressOrOtherLandLocation),
+      propertyAddress= Some(address),
       tenure= Some("Freehold"), tenancyType= Some("Vacant Possession"),
       yearsLeftOnLease= Some(0),
       yearsLeftOntenancyAgreement= Some(0)
@@ -516,11 +514,9 @@ object IHTReturnTestHelper {
   }
 
   def buildAssetsPropertiesOtherResidentialBuilding = {
-    val addressOrOtherLandLocation = AddressOrOtherLandLocation(
-      address = Some(models.des.Address(addressLine1= "addr1", addressLine2= "addr2",
+    val address = models.des.Address(addressLine1= "addr1", addressLine2= "addr2",
         addressLine3= None, addressLine4= None,
-        postalCode= CommonBuilder.DefaultPostCode, countryCode= "GB"))
-    )
+        postalCode= CommonBuilder.DefaultPostCode, countryCode= "GB")
 
     val liability1 = Liability(
       liabilityType=Some("Mortgage"),
@@ -540,7 +536,7 @@ object IHTReturnTestHelper {
       //      liabilities= None,
 
       // Property asset
-      propertyAddress= Some(addressOrOtherLandLocation),
+      propertyAddress= Some(address),
       tenure= Some("Leasehold"), tenancyType= Some("Vacant Possession"),
       yearsLeftOnLease= Some(0),
       yearsLeftOntenancyAgreement= Some(0)
@@ -548,11 +544,9 @@ object IHTReturnTestHelper {
   }
 
   def buildAssetsPropertiesLandNonRes = {
-    val addressOrOtherLandLocation = AddressOrOtherLandLocation(
-      address = Some(models.des.Address(addressLine1= "addr1", addressLine2= "addr2",
+    val address = models.des.Address(addressLine1= "addr1", addressLine2= "addr2",
         addressLine3= None, addressLine4= None,
-        postalCode= CommonBuilder.DefaultPostCode, countryCode= "GB"))
-    )
+        postalCode= CommonBuilder.DefaultPostCode, countryCode= "GB")
 
     Asset(
       // General asset
@@ -564,7 +558,7 @@ object IHTReturnTestHelper {
       devolutions= None,
 
       // Property asset
-      propertyAddress= Some(addressOrOtherLandLocation),
+      propertyAddress= Some(address),
       tenure= Some("Leasehold"), tenancyType= Some("Vacant Possession"),
       yearsLeftOnLease= Some(0),
       yearsLeftOntenancyAgreement= Some(0)

--- a/test/iht/utils/pdf/PdfFormatterTest.scala
+++ b/test/iht/utils/pdf/PdfFormatterTest.scala
@@ -26,7 +26,7 @@ import iht.testhelpers.{CommonBuilder, IHTReturnTestHelper, TestHelper}
 import org.joda.time.LocalDate
 import play.api.i18n.Lang
 
-import scala.collection.immutable.ListMap
+import scala.collection.immutable.{ListMap, ListSet}
 
 /**
   * Created by david-beer on 21/11/16.
@@ -412,7 +412,7 @@ class PdfFormatterTest extends FormTestHelper with PdfHelper {
         propertyList = List(propertyDeceasedHome, propertyOtherResidentialBuilding)
       )
 
-      val optionSetAsset = Some(Set(
+      val optionSetAsset = Some(ListSet(
         IHTReturnTestHelper.buildJointAssetMoney,
         IHTReturnTestHelper.buildAssetHouseholdAndPersonalItems,
         IHTReturnTestHelper.buildAssetPrivatePensions,


### PR DESCRIPTION
# DL-5108 Post submission PDF address bug fix

**Bug fix**

When a user request's a post submission estate report PDF, it does not show the assets property address's. This is due to a mismatch between the data being returned and the case class model where the structure for property address's is different.

## Checklist

*Reviewee*
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* 
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
