### PR TITLE
DL-6455 - Changed exception handler for Citizen Details

### DIFF
--- a/test/iht/testhelpers/MockObjectBuilder.scala
+++ b/test/iht/testhelpers/MockObjectBuilder.scala
@@ -26,7 +26,8 @@ import iht.testhelpers.CommonBuilder._
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.stubbing.OngoingStubbing
-import uk.gov.hmrc.http.NotFoundException
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import play.api.http.Status.NOT_FOUND
 
 import scala.concurrent.Future
 
@@ -66,7 +67,7 @@ trait MockObjectBuilder {
     when(connector.getCitizenDetails(any())(any(), any())).thenThrow(new RuntimeException)
 
   def createMockToThrowNotFoundExceptionWhenGettingCitizenDetails(connector: CitizenDetailsConnector) =
-    when(connector.getCitizenDetails(any())(any(), any())).thenReturn(Future.failed(new NotFoundException("")))
+    when(connector.getCitizenDetails(any())(any(), any())).thenReturn(Future.failed(UpstreamErrorResponse("citizen details 404", NOT_FOUND)))
 
   /**
     * Creates Mock to store RegistrationDetails in Cache using CachingConnector


### PR DESCRIPTION
# DL-6455 - Changed exception handler for Citizen Details

Relates to https://github.com/hmrc/iht-stub/pull/19
- Changed citizenDetails error handler to the new UpstreamErrorResponse type
- Added logging for both 404s and 423s.

## Checklist

*Stephen*
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
