### PR TITLE
DL-5959 - Added MCI page

### DIFF
--- a/app/assets/stylesheets/partials/_typography.scss
+++ b/app/assets/stylesheets/partials/_typography.scss
@@ -92,3 +92,6 @@ reduce top margin on Get Help With This Page to allow N
     margin-top: 0;
 }
 
+.mci-heading {
+    margin-bottom: .9em;
+}

--- a/app/iht/config/ApplicationConfig.scala
+++ b/app/iht/config/ApplicationConfig.scala
@@ -75,4 +75,5 @@ trait AppConfig extends IhtProperties {
   // Default visibility - off in PROD and on in every other env
   lazy val isWelshEnabled: Boolean = Try(servicesConfig.getBoolean("welsh.enabled")).getOrElse(runningEnvironment != "PROD")
 
+  lazy val hmrcCallChargesUrl: String = readFromConfig("urls.hmrcCallChargesUrl")
 }

--- a/app/iht/controllers/registration/CitizenDetailsNotFoundController.scala
+++ b/app/iht/controllers/registration/CitizenDetailsNotFoundController.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iht.controllers.registration
+
+import iht.config.AppConfig
+import iht.connector.CachingConnector
+import iht.views.html.registration.registration_error_citizenDetails
+import javax.inject.Inject
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.Future
+
+class CitizenDetailsNotFoundController @Inject()(registrationErrorCitizenDetailsView: registration_error_citizenDetails,
+                                                 val cc: MessagesControllerComponents,
+                                                 val appConfig: AppConfig,
+                                                 val authConnector: AuthConnector,
+                                                 val cachingConnector: CachingConnector
+                                                ) extends FrontendController(cc) with  RegistrationController {
+  override def guardConditions: Set[Predicate] = Set.empty
+
+  def onPageLoad: Action[AnyContent] = authorisedForIht { implicit request =>
+    Future.successful(Ok(registrationErrorCitizenDetailsView()))
+  }
+}

--- a/app/iht/controllers/registration/ManualCorrespondenceIndicatorController.scala
+++ b/app/iht/controllers/registration/ManualCorrespondenceIndicatorController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iht.controllers.registration
+
+import iht.config.AppConfig
+import iht.connector.CachingConnector
+import iht.views.html.registration.registration_error_manual_correspondence_indicator
+import javax.inject.Inject
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.Future
+
+class ManualCorrespondenceIndicatorController @Inject()(registrationMCIView: registration_error_manual_correspondence_indicator,
+                                                        val cc: MessagesControllerComponents,
+                                                        val appConfig: AppConfig,
+                                                        val authConnector: AuthConnector,
+                                                        val cachingConnector: CachingConnector,
+                                                       ) extends FrontendController(cc) with  RegistrationController {
+
+  override def guardConditions: Set[Predicate] = Set.empty
+
+  def onPageLoad = authorisedForIht { implicit request =>
+    Future.successful(Ok(registrationMCIView()))
+  }
+
+}

--- a/app/iht/views/registration/registration_error_citizenDetails.scala.html
+++ b/app/iht/views/registration/registration_error_citizenDetails.scala.html
@@ -19,12 +19,12 @@
     ihtMainTemplateRegistration: iht_main_template_registration
 )
 
-@(title: String, message: String)(implicit request : Request[_], messages: Messages)
+@()(implicit request : Request[_], messages: Messages)
 
-@ihtMainTemplateRegistration(title = messages(title), browserTitle = Some(messages(title)),
+@ihtMainTemplateRegistration(title = messages("page.iht.registration.applicantDetails.citizenDetailsNotFound.title"), browserTitle = Some(messages("page.iht.registration.applicantDetails.citizenDetailsNotFound.title")),
  hasTimeOut=true) {
 
-   <p>@messages(message)</p>
+   <p>@messages("page.iht.registration.applicantDetails.citizenDetailsNotFound.guidance")</p>
 
    <div id="continue-button">
    <a class="button" href="@iht.controllers.routes.SessionManagementController.signOut.url">@messages("site.button.signOut")</a>

--- a/app/iht/views/registration/registration_error_manual_correspondence_indicator.scala.html
+++ b/app/iht/views/registration/registration_error_manual_correspondence_indicator.scala.html
@@ -1,0 +1,48 @@
+@*
+* Copyright 2021 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+
+@import iht.config.AppConfig
+
+@this(
+    ihtMainTemplateRegistration: iht_main_template_registration,
+    appConfig: AppConfig
+)
+
+@()(implicit request : Request[_], messages: Messages)
+
+@ihtMainTemplateRegistration(
+    title = messages("page.iht.registration.applicantDetails.mci.heading"),
+    browserTitle = Some(messages("page.iht.registration.applicantDetails.mci.title")),
+    headingClass = "heading-xlarge mci-heading",
+hasTimeOut=true) {
+
+<p>@messages("page.iht.registration.applicantDetails.mci.p1")</p>
+<h2 class="heading-medium" style="margin-top: 1.25em;">@messages("page.iht.registration.applicantDetails.mci.subheading.1")</h2>
+<ul class="list-bullet">
+    <li style="margin-bottom: 5px">@messages("page.iht.registration.applicantDetails.mci.contact.li.1")</li>
+    <li style="margin-bottom: 5px">@messages("page.iht.registration.applicantDetails.mci.contact.li.2")</li>
+    <li style="margin-bottom: 5px">@messages("page.iht.registration.applicantDetails.mci.contact.li.3")</li>
+</ul>
+<p style="margin-top: 1.25em; margin-bottom: 1em">@messages("page.iht.registration.applicantDetails.mci.subheading.2")</p>
+<ul class="list-bullet">
+    <li style="margin-bottom: 5px">@messages("page.iht.registration.applicantDetails.mci.schedule.li.1")</li>
+    <li style="margin-bottom: 5px">@messages("page.iht.registration.applicantDetails.mci.schedule.li.2")</li>
+    <li style="margin-bottom: 5px">@messages("page.iht.registration.applicantDetails.mci.schedule.li.3")</li>
+</ul>
+<p style="margin-top: 19px; margin-bottom: 1em">@messages("page.iht.registration.applicantDetails.mci.p2")</p>
+<p><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@appConfig.hmrcCallChargesUrl">@messages("page.iht.registration.applicantDetails.mci.contact.charges.href")</a></p>
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -153,3 +153,5 @@ feedback-survey-frontend {
 }
 
 accessibility-statement.service-path = "/inheritance-tax"
+
+urls.hmrcCallChargesUrl = "https://www.gov.uk/call-charges"

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1997,6 +1997,20 @@ site.tnrb.value = 650,000
 page.iht.registration.applicantDetails.citizenDetailsNotFound.title = Ni all CThEM ddod o hyd i unrhyw fanylion amdanoch.
 page.iht.registration.applicantDetails.citizenDetailsNotFound.guidance = Mae''n rhaid i chi ffonio''r llinell gymorth Treth Etifeddiant ar 0300 123 1072. Ffoniwch +44 300 123 1072 os ydych y tu allan i''r DU.
 
+page.iht.registration.applicantDetails.mci.title = Dangosydd Gohebiaeth â Llaw
+page.iht.registration.applicantDetails.mci.heading = Ni allwch gael mynediad at eich cyfrif ar hyn o bryd
+page.iht.registration.applicantDetails.mci.p1 = Mae angen i ni siarad â chi am wall MCI (Dangosydd Gohebiaeth â Llaw) cyn i chi allu mewngofnodi.
+page.iht.registration.applicantDetails.mci.subheading.1 = Sut i gysylltu â ni
+page.iht.registration.applicantDetails.mci.contact.li.1 = Ffôn: 0300 200 1900
+page.iht.registration.applicantDetails.mci.contact.li.2 = Ffôn testun: 0300 200 3319
+page.iht.registration.applicantDetails.mci.contact.li.3 = O''r tu allan i''r DU: +44 300 200 1900
+page.iht.registration.applicantDetails.mci.subheading.2 = Mae''r llinellau ffôn ar agor:
+page.iht.registration.applicantDetails.mci.schedule.li.1 = 08:30 – 17:00 o ddydd Llun i ddydd Gwener
+page.iht.registration.applicantDetails.mci.schedule.li.2 = Ar gau ar ddydd Sadwrn
+page.iht.registration.applicantDetails.mci.schedule.li.3 = Ar gau ar ddydd Sul
+page.iht.registration.applicantDetails.mci.p2 = Ar gau ar wyliau banc
+page.iht.registration.applicantDetails.mci.contact.charges.href = Gwybodaeth am gostau galwadau (yn agor tab newydd)
+
 page.iht.filter.useService.under325000.otherWaysToReportValue = Ffyrdd eraill i roi gwybod am werth ystâd
 page.iht.filter.useService.under325000.p1.a = Gallwch
 page.iht.filter.useService.under325000.p1.b = ddefnyddio''r ffurflen bapur IHT205

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -428,6 +428,20 @@ page.iht.registration.applicantAddress.hint = This is where HMRC can contact you
 page.iht.registration.applicantDetails.citizenDetailsNotFound.title = HMRC cannot find any details about you.
 page.iht.registration.applicantDetails.citizenDetailsNotFound.guidance = You must call the Inheritance Tax helpline on 0300 123 1072 to continue with this registration, Call +44 300 123 1072 if you are outside of the UK.
 
+page.iht.registration.applicantDetails.mci.title = Manual Correspondence Indicator
+page.iht.registration.applicantDetails.mci.heading = You cannot access your account right now
+page.iht.registration.applicantDetails.mci.p1 = We need to talk to you about an MCI error before you can sign in.
+page.iht.registration.applicantDetails.mci.subheading.1 = How to contact us
+page.iht.registration.applicantDetails.mci.contact.li.1 = Telephone: 0300 200 3300
+page.iht.registration.applicantDetails.mci.contact.li.2 = Textphone: 0300 200 3319
+page.iht.registration.applicantDetails.mci.contact.li.3 = Outside UK: +44 135 535 9022
+page.iht.registration.applicantDetails.mci.subheading.2 = Phone lines are open:
+page.iht.registration.applicantDetails.mci.schedule.li.1 = 8am to 8pm Monday to Friday
+page.iht.registration.applicantDetails.mci.schedule.li.2 = 8am to 4pm Saturdays
+page.iht.registration.applicantDetails.mci.schedule.li.3 = 9am to 5pm Sundays
+page.iht.registration.applicantDetails.mci.p2 = Closed bank holidays
+page.iht.registration.applicantDetails.mci.contact.charges.href = Find out more about call charges (opens in new tab)
+
 #Registration - Applicant Apply for probate
 page.iht.registration.applicant.probateLocation.title = Where are you going to apply for probate?
 page.iht.registration.applicant.probateLocation.browserTitle = Probate location
@@ -2636,3 +2650,5 @@ page.iht.application.overview.closed.viewClearanceCertificate = View this estate
 page.iht.application.overview.closed.p1 = This certificate confirms that we will not make any future tax claims on the estate based on the details you have given in the estate report.
 
 page.iht.questionnaire.intendReturn.question=Do you intend to come back later to complete your estate report?
+
+

--- a/conf/registration.routes
+++ b/conf/registration.routes
@@ -150,6 +150,10 @@ GET         /already-registered/:ihtReference                   @iht.controllers
 GET         /not-possible-to-use-service                        @iht.controllers.registration.KickoutRegController.onPageLoad
 POST        /not-possible-to-use-service                        @iht.controllers.registration.KickoutRegController.onSubmit
 
+GET         /manual-correspondence-indicator                    @iht.controllers.registration.ManualCorrespondenceIndicatorController.onPageLoad
+
+GET         /details-not-found                                  @iht.controllers.registration.CitizenDetailsNotFoundController.onPageLoad
+
 ### To do ####
 
 ### Routes below to be removed after completion of Yes/No changes ###

--- a/test/iht/controllers/registration/CitizenDetailsNotFoundControllerTest.scala
+++ b/test/iht/controllers/registration/CitizenDetailsNotFoundControllerTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iht.controllers.registration
+
+import iht.views.html.registration.registration_error_citizenDetails
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import play.api.i18n.MessagesApi
+import play.api.mvc.{AnyContentAsEmpty, Result}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import scala.concurrent.Future
+
+class CitizenDetailsNotFoundControllerTest extends RegistrationControllerTest {
+
+  val controller = new CitizenDetailsNotFoundController(app.injector.instanceOf[registration_error_citizenDetails],
+    mockControllerComponents,
+    mockAppConfig,
+    mockAuthConnector,
+    mockCachingConnector)
+
+  implicit val req: FakeRequest[AnyContentAsEmpty.type] = createFakeRequest(authRetrieveNino = false)
+  implicit val messages: MessagesApi = app.injector.instanceOf[MessagesApi]
+  "CitizenDetailsNotFoundController" must {
+    "load the page for authorized users" in {
+      when(mockAuthConnector.authorise[Unit](any(), any())(any(), any())).thenReturn(Future.successful(()))
+      val result: Future[Result] = controller.onPageLoad(implicitly)
+      status(result) mustBe OK
+      contentAsString(result) must include(messagesApi("page.iht.registration.applicantDetails.citizenDetailsNotFound.title"))
+    }
+  }
+}

--- a/test/iht/controllers/registration/ManualCorrespondenceIndicatorControllerTest.scala
+++ b/test/iht/controllers/registration/ManualCorrespondenceIndicatorControllerTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iht.controllers.registration
+
+import iht.views.html.registration.registration_error_manual_correspondence_indicator
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import play.api.i18n.MessagesApi
+import play.api.mvc.{AnyContentAsEmpty, Result}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import scala.concurrent.Future
+
+class ManualCorrespondenceIndicatorControllerTest extends RegistrationControllerTest {
+
+  val controller = new ManualCorrespondenceIndicatorController(
+    app.injector.instanceOf[registration_error_manual_correspondence_indicator],
+    mockControllerComponents,
+    mockAppConfig,
+    mockAuthConnector,
+    mockCachingConnector
+  )
+
+  implicit val req: FakeRequest[AnyContentAsEmpty.type] = createFakeRequest(authRetrieveNino = false)
+  implicit val messages: MessagesApi = app.injector.instanceOf[MessagesApi]
+  "ManualCorrespondenceIndicatorController" must {
+    "load the page for authorized users" in {
+      when(mockAuthConnector.authorise[Unit](any(), any())(any(), any())).thenReturn(Future.successful(()))
+      val result: Future[Result] = controller.onPageLoad(implicitly)
+      status(result) mustBe OK
+      contentAsString(result) must include(messagesApi("page.iht.registration.applicantDetails.mci.title"))
+    }
+  }
+}

--- a/test/iht/testhelpers/MockObjectBuilder.scala
+++ b/test/iht/testhelpers/MockObjectBuilder.scala
@@ -27,7 +27,7 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.stubbing.OngoingStubbing
 import uk.gov.hmrc.http.UpstreamErrorResponse
-import play.api.http.Status.NOT_FOUND
+import play.api.http.Status.{NOT_FOUND, LOCKED}
 
 import scala.concurrent.Future
 
@@ -68,6 +68,9 @@ trait MockObjectBuilder {
 
   def createMockToThrowNotFoundExceptionWhenGettingCitizenDetails(connector: CitizenDetailsConnector) =
     when(connector.getCitizenDetails(any())(any(), any())).thenReturn(Future.failed(UpstreamErrorResponse("citizen details 404", NOT_FOUND)))
+
+  def createMockToThrowLockedExceptionWhenGettingCitizenDetails(connector: CitizenDetailsConnector) =
+    when(connector.getCitizenDetails(any())(any(), any())).thenReturn(Future.failed(UpstreamErrorResponse("citizen details 423", LOCKED)))
 
   /**
     * Creates Mock to store RegistrationDetails in Cache using CachingConnector


### PR DESCRIPTION
# DL-5959 - Added MCI page

Added MCI page and moved MCI/Citizen Details not found pages to their own routes:
`/inheritance-tax/registration/details-not-found`
`/inheritance-tax/registration/manual-correspondence-indicator`

MCI is stubbed to NINO ST281614A

## Checklist

*Stephen*
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
