### PR TITLE
DL-6736 - Removed word wrap from hint text

### DIFF
--- a/app/iht/views/application/debts/jointly_owned.scala.html
+++ b/app/iht/views/application/debts/jointly_owned.scala.html
@@ -32,7 +32,7 @@
 @(jointlyOwnedDebtsForm: Form[BasicEstateElementLiabilities],
   registrationDetails: RegistrationDetails)(implicit request: Request[_], messages: Messages)
 
-@deceasedName = @{DeceasedInfoHelper.getDeceasedNameOrDefaultString(registrationDetails, true)}
+@deceasedName = @{DeceasedInfoHelper.getDeceasedNameOrDefaultString(registrationDetails)}
 
 @ihtMainTemplateApplication(title = Messages("iht.estateReport.debts.owedOnJointAssets"),
     browserTitle = Some(Messages("page.iht.application.debts.jointlyOwned.browserTitle")),


### PR DESCRIPTION
# DL-6736 - Removed word wrap from hint text

The deceased name for the attached page has word-wrap turned on (which adds HTML to the string), but hint text doesn't render HTML. This PR switches word-wrapping off for this page's hint text.

## Before
<img width="999" alt="qa tax service gov ukinheritance-taxestate-reportjoint-debts" src="https://user-images.githubusercontent.com/56881842/141828404-be949547-7e27-4351-a992-520571b3fba8.png">

## After
<img width="1083" alt="Screenshot 2021-11-15 at 17 40 25" src="https://user-images.githubusercontent.com/56881842/141828728-907c8bb6-95f8-4938-a885-4ba60e7c2967.png">
