### PR TITLE
DL-7091: abbreviations links changed for iht400 & iht205, updated bac…

### DIFF
--- a/app/iht/views/filter/domicile.scala.html
+++ b/app/iht/views/filter/domicile.scala.html
@@ -25,7 +25,9 @@
 
 @(ihtForm: Form[Option[String]])(implicit request:Request[_], messages: Messages)
 
-@ihtMainTemplateRegistration(title = Messages("page.iht.registration.deceasedPermanentHome.title"),
+@ihtMainTemplateRegistration(
+    backUrl = Some(iht.controllers.filter.routes.FilterController.onPageLoad),
+    title = Messages("page.iht.registration.deceasedPermanentHome.title"),
     browserTitle = Some(Messages("page.iht.registration.deceasedPermanentHome.title")),
     isFullWidth = false,
     hasSignOut = false,
@@ -51,8 +53,5 @@ FieldMappings.domicileChoices.toSeq,
     <input id='continue' class='button' type='submit' value='@Messages("iht.continue")'>
 </div>
 
-<a id="return-link" href="@iht.controllers.filter.routes.FilterController.onPageLoad().url">
-    @Messages("page.iht.filter.domicile.return.link")
-</a>
 }
 }

--- a/app/iht/views/iht_main_template.scala.html
+++ b/app/iht/views/iht_main_template.scala.html
@@ -148,6 +148,9 @@
 }
 
     @mainContentIht = {
+    @backUrl.map{ url =>
+        <a id="back-button" class="back-link" href=@url>@Messages("iht.back")</a>
+    }
     @if(title > ""){
         @highlightBoxClass.map{css=>
             <div class="@css">
@@ -168,9 +171,6 @@
     }
     @mainContent
 
-    @backUrl.map{ url =>
-        <a id="back-button" class="back-link" href=@url>@Messages("iht.back")</a>
-    }
     @cancelUrl.map{ url =>
         <p>
             <a id="cancel-button" class="" href=@url>@Html(cancelLabel.getOrElse(""))</a>

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -258,7 +258,7 @@ iht.address.line2=Cyfeiriad – llinell 2
 iht.estateReport.debts.funeralExpenses.title=Treuliau angladd
 page.iht.application.exemptions.overview.qualifyingBody.screenReader.link.value=Newidiwch y swm ar gyfer asedion a adawyd i gyrff cymwys eraill
 page.iht.application.assets.businessInterest.browserTitle=Diddordebau busnes a berchnogwyd
-page.iht.filter.paperform.northern.ireland.iht205.link.text=ffurflen IHT205
+page.iht.filter.paperform.northern.ireland.iht205.link.text=ffurflen Treth Etifeddiant 205
 page.iht.registration.executor-overview.yesnoQuestion=A ydych eisiau ychwanegu person arall sy’n gwneud cais am brofiant?
 page.iht.application.exemptions.charityNumber.p1=Cewch hyd i rif yr elusen gofrestredig ar wefan y Comisiwn Elusennau drwy
 error.phoneNumber.giveUsing27CharactersOrLess=Rhowch rif ffôn gan ddefnyddio hyd at 27 o gymeriadau
@@ -811,14 +811,14 @@ page.iht.application.exemptions.overview.qualifyingBody.detailsOverview.value.li
 iht.registration.contactAddress=Cyfeiriad cyswllt
 page.iht.application.exemptions.charityNumber.linkText=chwilio’r gofrestr elusennau (yn agor ffenestr neu dab newydd).
 page.iht.application.overview.debts.screenReader.noValue.link=Dechreuwch roi fanylion am ddyledion sy’n ddyledus o’r ystâd
-page.iht.filter.paperform.iht400.link.text=ffurflen IHT400
+page.iht.filter.paperform.iht400.link.text=ffurflen Treth Etifeddiant 400
 page.iht.application.debts.debtsTrust.browserTitle=Dyledion sy’n ddyledus o ymddiriedolaeth
 page.iht.application.overview.inreview.title=Rydym yn adolygu’r adroddiad ynghylch ystâd {0}
 page.iht.application.gifts.lastYears.givenAway.p1=Mae angen i chi gael gwybod pa roddion a rodd {0} i ffwrdd ymhob un o’r 7 mlynedd cyn marw.
 site.button.save.return.debts=Cadw ac yn ôl i ddyledion sydd ar yr ystâd
 page.iht.registration.applicantDetails.countrycode.help=Os nad yw eich cyfeiriad yn y DU
 iht.estateReport.debts.debtsTrust.value=Swm unrhyw ddyledion sy’n ddyledus o ymddiriedolaeth
-page.iht.filter.paperform.million.exit=Gadael ac i’r ffurflen IHT400
+page.iht.filter.paperform.million.exit=Gadael a mynd i’r ffurflen Treth Etifeddiant 400
 page.iht.home.title=Eich adroddiadau Treth Etifeddiant ynghylch yr ystâd
 page.iht.application.assets.deceased-permanent-home.question4.hint=Os nad oedd yr ymadawedig yn byw mewn eiddo roedd yn berchen arno, dylech ddewis cartref yr ymadawedig os mai hwn oedd yr eiddo diwethaf roedd yn berchen arno, a’n byw ynddo’n ogystal.
 page.iht.application.tnrb.kickout.estateMoreThanThreshold.summary=Y rheswm dros hynny yw bod gwerth yr ystâd dros y drothwy Treth Etifeddiant.
@@ -843,7 +843,7 @@ page.iht.registration.notApplyingForProbate.kickout.expander.p5=Ym mhob achos, r
 page.iht.registration.notApplyingForProbate.kickout.expander.p6=Os nad ydych yn siŵr a yw’r ystâd wedi’i heithrio, ffoniwch Wasanaeth Cwsmeriaid Cymraeg CThEM ar 0300 200 1900 (+44 300 123 1072 o dramor – Saesneg yn unig).
 page.iht.registration.notApplyingForProbate.kickout.p2 = Os nad oes angen profiant arnoch, nid oes yn rhaid i chi roi gwybod i CThEM am ddim byd, cyhyd â bod yr ystâd wedi’i heithrio.
 page.iht.registration.notApplyingForProbate.kickout.p1=Mae’ch atebion blaenorol ynglŷn â gwerth yr ystâd yn awgrymu y gallai fod yn ystâd sydd wedi’i heithrio.
-page.iht.registration.notApplyingForProbate.kickout.p3=Os nad yw’r ystâd wedi’i heithrio, rhaid i chi lenwi <a href="{0}" id="iht400">Ffurflen IHT400 yn llawn</a>, p’un a oes angen profiant arnoch ai peidio, a ph’un a yw Treth Etifeddiant yn daladwy ai peidio. Os na fyddwch yn llenwi Ffurflen, mae’n bosibl y cewch gosb.
+page.iht.registration.notApplyingForProbate.kickout.p3=Os nad yw’r ystâd wedi’i heithrio, rhaid i chi lenwi <a href="{0}" id="iht400">Ffurflen lawn (Treth Etifeddiant 400), p’un a oes angen profiant arnoch ai peidio, a ph’un a yw Treth Etifeddiant yn daladwy ai peidio. Os na fyddwch yn llenwi Ffurflen, mae’n bosibl y cewch gosb.
 
 page.iht.application.assets.property.ownership.browserTitle=Beth oedd perchnogaeth yr eiddo
 page.iht.application.assets.pensions.hint=Bydd y darparwr pensiwn yn gallu rhoi gwybod i chi faint sy’n cael ei dalu i’r ystad.
@@ -1154,7 +1154,7 @@ error.isAssetForDeceasedPartner.select=Dewiswch ateb ar gyfer os oes unrhyw ased
 page.iht.home.applicationList.table.guidance.label=Dyma’r holl adroddiadau Treth Etifeddiant ynghylch yr ystâd rydych wedi’u cofrestru.
 error.registration.serviceUnavailable.p1=Arhoswch ychydig o eiliadau ac yna rhowch gynnig arall arni.
 error.estateOverview.jsonError.p1=Ni allwch lenwi’ch adroddiad ynghylch yr ystâd ar-lein. Mae hyn oherwydd gwall yn ein system.
-error.estateOverview.jsonError.p2=Defnyddiwch y <a id="paperFormLink" href="{0}">ffurflen bapur IHT205</a> i roi gwybod am werth yr ystâd yn lle hynny.
+error.estateOverview.jsonError.p2=Defnyddiwch y <a id="paperFormLink" href="{0}">ffurflen Treth Etifeddiant 205 – (fersiwn bapur)</a> i roi gwybod am werth yr ystâd yn lle hynny.
 error.estateReport.serviceUnavailable.p3=Os gwelwch y neges hon sawl gwaith, gallwch allgofnodi nawr a rhoi cynnig arall ar gyflwyno’ch adroddiad nes ymlaen yn <a id="declarationLink" href="{0}">https://www.tax.service.gov.uk/inheritance-tax/estate-report/declaration</a> (dylech gadw’r cysylltiad hwn).
 error.assets.nominated.select=Dewiswch ateb ar gyfer a oes unrhyw asedion enwebedig yn yr ystâd
 iht.estateReport.assets.qualifyingBodyAdd=Ychwanegwch gorff cymwys
@@ -1173,7 +1173,7 @@ page.iht.application.overview.title=Mae’r broses o wneud cais ar gyfer {0} naw
 iht.gov.url=https://www.gov.uk/inheritance-tax
 page.iht.sign.out=Allgofnodi
 error.registration.serviceUnavailable.p2=Os gwelwch y neges hon sawl gwaith, bydd yn rhaid i chi allgofnodi a chofrestru eto nes ymlaen yn <a id="registrationChecklistLink" href="{0}">https://www.tax.service.gov.uk/inheritance-tax/registration/registration-checklist</a> (dylech gadw’r cysylltiad hwn).
-error.registration.serviceUnavailable.p3=Gallwch ddewis rhoi gwybod am werth yr ystâd gan ddefnyddio’r <a id="registrationChecklistLink" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459774/IHT205_2011__Cymraeg.pdf">ffurflen bapur IHT205</a> yn lle hynny.
+error.registration.serviceUnavailable.p3=Gallwch ddewis rhoi gwybod am werth yr ystâd gan ddefnyddio’r <a id="registrationChecklistLink" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459774/IHT205_2011__Cymraeg.pdf">ffurflen Treth Etifeddiant 205 – (fersiwn bapur)</a> yn lle hynny.
 error.dateOfBirth.giveCorrectDateUsingOnlyNumbers=Rhowch ddyddiad geni cywir gan ddefnyddio rhifau’n unig
 page.iht.application.assets.tenure.freehold.hint=Roedd {0} yn berchen ar yr eiddo a’r tir y mae’n sefyll arno.
 page.iht.application.exemptions.qualifyingBodyDelete.browserTitle=Dilëwch gorff cymwys
@@ -1519,7 +1519,7 @@ page.iht.filter.anyAssets.summary.p2.b = sut i gyfrifo a rhoi gwybod am werth ys
 page.iht.filter.noAssets.title = Sut i ddatgan does dim asedion
 page.iht.filter.noAssets.heading = Sut i ddatgan does dim asedion
 page.iht.filter.noAssets.label.a = Os ydych yn siŵr nad oedd gan y person a fu farw unrhyw asedion o gwbl, ni allwch ddefnyddio’r gwasanaeth ar-lein hwn. Mae’n rhaid i chi ddefnyddio {0} {1}
-page.iht.filter.noAssets.label.b = Ffurflen IHT400 (yn agor tab newydd)
+page.iht.filter.noAssets.label.b = ffurflen Treth Etifeddiant 400 (yn agor tab newydd)
 page.iht.filter.noAssets.label.c = i roi gwybod i CThEM am hyn.
 
 page.iht.application.TnrbEligibilty.spouseOrCivilPartner.commonText=priod neu bartner sifil
@@ -2045,7 +2045,7 @@ page.iht.registration.applicantDetails.mci.contact.charges.href = Gwybodaeth am 
 
 page.iht.filter.useService.under325000.otherWaysToReportValue = Ffyrdd eraill i roi gwybod am werth ystâd
 page.iht.filter.useService.under325000.p1.a = Gallwch
-page.iht.filter.useService.under325000.p1.b = ddefnyddio’r ffurflen bapur IHT205
+page.iht.filter.useService.under325000.p1.b = defnyddiwch y ffurflen Treth Etifeddiant 205 - (fersiwn bapur)
 page.iht.filter.useService.under325000.p1.c = os na allwch roi gwybod ar-lein am werth yr ystâd.
 page.iht.filter.useService.under325000.p2 = Os na allwch lawrlwytho neu argraffu’r ffurflen, gallwch ofyn bod copi’n cael ei anfon atoch drwy ffonio’r llinell gymorth Treth Etifeddiant ar 0300 123 1072. Os ydych y tu allan i’r DU, ffoniwch +44 300 123 1072.
 
@@ -2056,8 +2056,8 @@ page.iht.filter.jointlyowned.no = Nac oedd, nid oedd yn berchen ar rywbeth ar y 
 
 page.iht.filter.useService.between325000And1Million.paragraph0 = Os yw gwerth gros yr ystâd (h.y. y gwerth cyn i chi dynnu dyledion a morgeisi) rhwng £325,000 ac £1 miliwn, efallai y bydd angen i chi ddefnyddio
 page.iht.filter.useService.between325000And1Million.title = Efallai y bydd angen i chi ddefnyddio ffurflen wahanol
-page.iht.filter.useService.between325000And1Million.IHTFormlink = ffurflen IHT400
-page.iht.filter.useService.between325000And1Million.IHTFormlink1 = ffurflen IHT400.
+page.iht.filter.useService.between325000And1Million.IHTFormlink = ffurflen Treth Etifeddiant 400
+page.iht.filter.useService.between325000And1Million.IHTFormlink1 = ffurflen Treth Etifeddiant 400.
 page.iht.filter.useService.between325000And1Million.section1.title = Os oes gan yr ystâd eithriadau
 page.iht.filter.useService.between325000And1Million.paragraph1  = i roi gwybod am werth yr ystâd.
 page.iht.filter.useService.between325000And1Million.paragraph2  = Mae dwy ffordd y gallwch barhau â’r gwasanaeth ar-lein hwn:
@@ -2092,7 +2092,7 @@ page.iht.filter.useService.between325000And1Million.iht400link = ei lawrlwytho a
 
 page.iht.filter.useService.between325000And1Million.section4.p1 = Gofynnir i chi fewngofnodi i gadarnhau pwy ydych gyda CThEM.
 page.iht.filter.useService.between325000And1Million.section4.p2.start = Gallwch ddefnyddio
-page.iht.filter.useService.between325000And1Million.section4.p2.link = ffurflen bapur IHT205
+page.iht.filter.useService.between325000And1Million.section4.p2.link = ffurflen Treth Etifeddiant 205 - (fersiwn bapur)
 page.iht.filter.useService.between325000And1Million.section4.p2.end = os na allwch roi gwybod ar-lein am werth yr ystâd.
 page.iht.filter.useService.between325000And1Million.section4.p3 = Os na allwch lawrlwytho neu argraffu’r ffurflen, gallwch ffonio’r Ganolfan Cyswllt Cymraeg ar 0300 200 1900 i ofyn am un.
 
@@ -2139,7 +2139,7 @@ page.iht.application.overview.common.ifYouNeed = I fynd yn eich blaen â’ch ca
 page.iht.application.overview.common.ifYouFind = Os darganfyddwch unrhyw beth arall yn yr ystâd
 page.iht.application.overview.common.p4 = Bydd ond yn rhaid i chi roi gwybod i ni os yw gwerth y pethau hynny’n mynd â gwerth yr ystâd dros y trothwy. Bydd Treth Etifeddiant i’w thalu.
 page.iht.application.overview.common.youWillNeedTo = Bydd angen i chi
-page.iht.application.overview.common.tellHMRC = roi gwybod i ni am yr ystâd drwy ddefnyddio ffurflen IHT400
+page.iht.application.overview.common.tellHMRC = rhowch wybod i ni am yr ystâd drwy ddefnyddio ffurflen Treth Etifeddiant 400
 page.iht.application.overview.common.needDetails = Rwyf angen y Dynodydd IHT, Ffigur Gros yr Ystâd a Ffigur Net yr Ystâd
 page.iht.application.overview.common.p1 = Gallwch wneud cais am brofiant o’r <a href="{0}">dudalen Ewyllysion a phrofiant.</a> Dyma’r manylion y bydd eu hangen arnoch:
 page.iht.application.overview.inreview.browserTitle = Rydym yn adolygu’r adroddiad hwn ynghylch yr ystâd
@@ -2158,7 +2158,7 @@ iht.iv.signIn = Mewngofnodi
 page.iht.iv.failure.cannotConfirmIdentity = Ni allwn gadarnhau pwy ydych
 page.iht.iv.failure.tryAgainOr = Gallwch roi cynnig arall arni neu:
 page.iht.iv.failure.youCanAlso = Gallwch hefyd:
-page.iht.iv.failure.reportWithPaperForm = rhoi gwybod am werth yr ystâd gan ddefnyddio’r <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459774/IHT205_2011__Cymraeg.pdf">ffurflen bapur IHT205</a> yn lle hynny
+page.iht.iv.failure.reportWithPaperForm = rhoi gwybod am werth yr ystâd gan ddefnyddio <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459774/IHT205_2011__Cymraeg.pdf">ffurflen Treth Etifeddiant 205 - (fersiwn bapur)</a> yn lle hynny
 page.iht.iv.failure.askForHelp = gofyn am help drwy e-bost gan ddefnyddio’r cysylltiad ‘Cael cymorth gyda’r dudalen hon’ isod
 
 page.iht.iv.failure.failedMatching.failureReason = Nid yw’r wybodaeth yr ydych wedi’i rhoi’n cyd-fynd â’r hyn sydd gennym yn ein cofnodion.
@@ -2176,7 +2176,7 @@ page.iht.iv.failure.incomplete.failureReason = Mae’n dal yn rhaid i ni gadarnh
 
 page.iht.iv.failure.preconditionFailed.heading = Ni allwch ddefnyddio’r gwasanaeth hwn
 page.iht.iv.failure.preconditionFailed.failureReason = Ni all CThEM gadarnhau pwy ydych o’r wybodaeth a roesoch.
-page.iht.iv.failure.preconditionFailed.usePaperForm = Defnyddiwch y <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459774/IHT205_2011__Cymraeg.pdf">ffurflen bapur IHT205</a> i roi gwybod am werth yr ystâd yn lle hynny.
+page.iht.iv.failure.preconditionFailed.usePaperForm = Defnyddiwch y <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459774/IHT205_2011__Cymraeg.pdf">ffurflen Treth Etifeddiant 205 – (fersiwn bapur)</a> i roi gwybod am werth yr ystâd yn lle hynny.
 
 page.iht.iv.failure.userAborted.failureReason = Nid ydych wedi rhoi digon o wybodaeth i ni.
 
@@ -2188,7 +2188,7 @@ page.iht.iv.failure.2fa.p1 = Bydd angen i chi sefydlu’r Dull Gwirio 2-Gam er m
 
 #New IV Error Content
 page.iht.iv.failure.couldNotConfirmIdentity=Nid oeddem yn gallu cadarnhau pwy ydych
-page.iht.iv.failure.youCanReport=Gallwch roi gwybod am werth yr ystâd gan ddefnyddio’r <a id="paperFormLink" href="{0}">ffurflen bapur IHT205</a> yn lle hynny.
+page.iht.iv.failure.youCanReport=Gallwch roi gwybod am werth yr ystâd gan ddefnyddio’r <a id="paperFormLink" href="{0}">ffurflen Treth Etifeddiant 205 – (fersiwn bapur)</a> yn lle hynny.
 page.iht.iv.failure.ifYouThink=Os ydych yn dal i feddwl bod gennych ateb i unrhyw un o’r cwestiynau, gallwch roi cynnig arall arni.
 page.iht.iv.failure.lockedOutTryAgain=Os ydych am roi cynnig arall arni, arhoswch am 24 awr ac yna ceisiwch fewngofnodi yn <a id="try-again" href="{0}">https://www.tax.service.gov.uk{0}</a>.
 page.iht.iv.failure.helpWithConfirm=Help gyda chadarnhau pwy ydych
@@ -2229,7 +2229,7 @@ page.iht.application.exemptions.guidance.increasing.threshold.section2.bullet3 =
 page.iht.application.exemptions.guidance.increasing.threshold.section2.bullet4 = elusen gofrestredig neu gorff cymwys arall megis clwb chwaraeon
 page.iht.application.exemptions.guidance.increasing.threshold.section2.p4 = Mae hyn yn golygu y bydd ond angen i chi ddangos i CThEM fod gwerth net yr ystâd yn is na’r trothwy. Caiff eithriadau, dyledion a morgeisi’r ystâd eu tynnu o werth yr ystâd cyn iddi gael ei gwirio yn erbyn y trothwy.  Mae’n rhaid i werth gros yr ystâd fod yn llai na £1 miliwn.
 page.iht.application.exemptions.guidance.increasing.threshold.section2.p5.start = Os nad oes eithriadau, ni ellir didynnu’r dyledion ar y cam hwn. Bydd yn rhaid i chi gyflwyno
-page.iht.application.exemptions.guidance.increasing.threshold.section2.p5.link = ffurflen IHT400
+page.iht.application.exemptions.guidance.increasing.threshold.section2.p5.link = ffurflen Treth Etifeddiant 400
 page.iht.application.exemptions.guidance.increasing.threshold.section2.p5.end = am y rheswm syml fod gwerth gros yr ystâd yn fwy na’r trothwy.
 
 page.iht.application.exemptions.guidance.increasing.threshold.section3.raisedHeader = Os gellir cynyddu’r trothwy
@@ -2244,7 +2244,7 @@ page.iht.application.exemptions.guidance.increasing.threshold.section4.p8 = Os g
 
 page.iht.application.exemptions.guidance.increasing.threshold.link.text = Yn ôl i’r adroddiadau ynghylch eich ystâd
 
-global.error.InternalServerError500.message1 = Os gwelwch y neges hon sawl gwaith, gallwch ddewis rhoi gwybod am werth yr ystâd gan ddefnyddio <a id="paperFormLink" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459774/IHT205_2011__Cymraeg.pdf">ffurflen bapur IHT205</a>
+global.error.InternalServerError500.message1 = Os gwelwch y neges hon sawl gwaith, gallwch ddewis rhoi gwybod am werth yr ystâd gan ddefnyddio <a id="paperFormLink" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459774/IHT205_2011__Cymraeg.pdf">ffurflen Treth Etifeddiant 205 – (fersiwn bapur)</a>
 
 #Estate Report - Get Help
 iht.estateReport.help = Help gyda’ch adroddiadau ynghylch yr ystâd

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -843,7 +843,7 @@ page.iht.registration.notApplyingForProbate.kickout.expander.p5=Ym mhob achos, r
 page.iht.registration.notApplyingForProbate.kickout.expander.p6=Os nad ydych yn siŵr a yw’r ystâd wedi’i heithrio, ffoniwch Wasanaeth Cwsmeriaid Cymraeg CThEM ar 0300 200 1900 (+44 300 123 1072 o dramor – Saesneg yn unig).
 page.iht.registration.notApplyingForProbate.kickout.p2 = Os nad oes angen profiant arnoch, nid oes yn rhaid i chi roi gwybod i CThEM am ddim byd, cyhyd â bod yr ystâd wedi’i heithrio.
 page.iht.registration.notApplyingForProbate.kickout.p1=Mae’ch atebion blaenorol ynglŷn â gwerth yr ystâd yn awgrymu y gallai fod yn ystâd sydd wedi’i heithrio.
-page.iht.registration.notApplyingForProbate.kickout.p3=Os nad yw’r ystâd wedi’i heithrio, rhaid i chi lenwi <a href="{0}" id="iht400">Ffurflen lawn (Treth Etifeddiant 400), p’un a oes angen profiant arnoch ai peidio, a ph’un a yw Treth Etifeddiant yn daladwy ai peidio. Os na fyddwch yn llenwi Ffurflen, mae’n bosibl y cewch gosb.
+page.iht.registration.notApplyingForProbate.kickout.p3=Os nad yw’r ystâd wedi’i heithrio, rhaid i chi lenwi <a href="{0}" id="iht400">Ffurflen lawn (Treth Etifeddiant 400)</a>, p’un a oes angen profiant arnoch ai peidio, a ph’un a yw Treth Etifeddiant yn daladwy ai peidio. Os na fyddwch yn llenwi Ffurflen, mae’n bosibl y cewch gosb.
 
 page.iht.application.assets.property.ownership.browserTitle=Beth oedd perchnogaeth yr eiddo
 page.iht.application.assets.pensions.hint=Bydd y darparwr pensiwn yn gallu rhoi gwybod i chi faint sy’n cael ei dalu i’r ystad.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -227,7 +227,7 @@ page.iht.filter.paperform.northern.ireland.p2.sentence1.start = If you already k
 page.iht.filter.paperform.northern.ireland.p2.sentence2.start = If you are not sure of the estate value, start filling in the
 page.iht.filter.paperform.northern.ireland.p2.sentence2.end = first.
 page.iht.filter.paperform.northern.ireland.p3 = You can read more about applying for probate in Northern Ireland on
-page.iht.filter.paperform.northern.ireland.iht205.link.text = IHT205 form
+page.iht.filter.paperform.northern.ireland.iht205.link.text = Inheritance Tax 205 form
 page.iht.filter.paperform.northern.ireland.nidirect.link.text = NIDIRECT.GOV.UK
 
 page.iht.filter.paperform.other.country.p1.sentence1.start = Reporting the estate value when the deceased had their permanent home outside of the UK is done by filling in an
@@ -237,17 +237,17 @@ page.iht.filter.paperform.other.country.iht401.link.text = IHT-401 paper form
 
 page.iht.filter.paperform.million.p1 = Because you think the value of the estate is more than £1 million, you will need to report the estate value by filling in an
 page.iht.filter.paperform.million.p2 = The form will guide you through what details you need to give and will tell you if there is any Inheritance Tax to pay.
-page.iht.filter.paperform.million.exit = Exit to the IHT400 form
+page.iht.filter.paperform.million.exit = Exit to the Inheritance Tax 400 form
 
-page.iht.filter.paperform.iht400.link.text = IHT400 form
+page.iht.filter.paperform.iht400.link.text = Inheritance Tax 400 form
 
 page.iht.filter.useService.under325000.paragraph0 = Because you think the estate might be worth less than £325,000, you can use the online service to report the estate value to HMRC.
 page.iht.filter.useService.paragraphFinal = You will need to register to use the service first, but before that, you will need to confirm who you are with HMRC.
 
 
 page.iht.filter.useService.between325000And1Million.paragraph0  = If the gross value of the estate (ie the value before you subtract debts and mortgages) is between £325,000 and £1 million, you may have to use the 
-page.iht.filter.useService.between325000And1Million.IHTFormlink = IHT400 form
-page.iht.filter.useService.between325000And1Million.IHTFormlink1 = IHT400 form.
+page.iht.filter.useService.between325000And1Million.IHTFormlink = Inheritance Tax 400 form
+page.iht.filter.useService.between325000And1Million.IHTFormlink1 = Inheritance Tax 400 form.
 page.iht.filter.useService.between325000And1Million.paragraph1  = to report the estate value.
 page.iht.filter.useService.between325000And1Million.paragraph2  = There are two ways that you can continue with this online service:
 page.iht.filter.useService.between325000And1Million.bullet1     = if the estate has exemptions
@@ -283,14 +283,14 @@ page.iht.filter.useService.between325000And1Million.iht400link = download and pr
 
 page.iht.filter.useService.between325000And1Million.section4.p1 = You’ll be asked to log in to confirm who you are with HMRC.
 page.iht.filter.useService.between325000And1Million.section4.p2.start = You can use the
-page.iht.filter.useService.between325000And1Million.section4.p2.link  = paper IHT205 form
+page.iht.filter.useService.between325000And1Million.section4.p2.link  = Inheritance Tax 205 form – (paper version)
 page.iht.filter.useService.between325000And1Million.section4.p2.end   = if you are not able to report the estate value online.
 page.iht.filter.useService.between325000And1Million.section4.p3 = If you are not able to download or print the form, you can call the Inheritance Tax helpline on 0300 123 1072 to request one.
 
 
 page.iht.filter.useService.under325000.otherWaysToReportValue = Other ways to report the value of an estate
 page.iht.filter.useService.under325000.p1.a = You can
-page.iht.filter.useService.under325000.p1.b = use the paper IHT205 form
+page.iht.filter.useService.under325000.p1.b = use the Inheritance Tax 205 form – (paper version)
 page.iht.filter.useService.under325000.p1.c = if you are not able to report the estate value online.
 page.iht.filter.useService.under325000.p2 = If you are not able to download or print the form, you can ask for a copy to be sent to you by calling the Inheritance Tax helpline on 0300 123 1072. If you are outside of the UK, call +44 300 123 1072.
 
@@ -331,7 +331,7 @@ page.iht.filter.anyAssets.summary.p2.b = how to work out and report the value of
 page.iht.filter.noAssets.title = How to declare no assets
 page.iht.filter.noAssets.heading = How to declare no assets
 page.iht.filter.noAssets.label.a = If you are sure that the person who died had no assets at all you cannot use this online service. You have to use an {0} {1}
-page.iht.filter.noAssets.label.b = IHT400 form (opens in new tab)
+page.iht.filter.noAssets.label.b = Inheritance Tax 400 form (opens in new tab)
 page.iht.filter.noAssets.label.c = to let HMRC know about this.
 
 #Registration
@@ -659,7 +659,7 @@ page.iht.registration.notApplyingForProbate.kickout.expander.bullet4 = a net val
 page.iht.registration.notApplyingForProbate.kickout.expander.p4 = Where an estate has exemptions you can subtract the exemptions and any debts such as mortgages or loans to give the net value.
 page.iht.registration.notApplyingForProbate.kickout.expander.p5 = In all cases the gross value of the estate must be below £1 million.
 page.iht.registration.notApplyingForProbate.kickout.expander.p6 = If you are not sure if the estate is excepted, call the Inheritance Tax helpline on 0300 123 1072 (44 300 123 1072 from overseas).
-page.iht.registration.notApplyingForProbate.kickout.p3 = If the estate is not excepted, you must complete a <a href="{0}" id="iht400">full return (IHT400)</a> whether you need probate or not, and whether Inheritance Tax is payable or not. If you do not complete a return, you may get a penalty.
+page.iht.registration.notApplyingForProbate.kickout.p3 = If the estate is not excepted, you must complete a <a href="{0}" id="iht400">full return (Inheritance Tax 400 form)</a> whether you need probate or not, and whether Inheritance Tax is payable or not. If you do not complete a return, you may get a penalty.
 
 page.iht.registration.notAnExecutor.kickout.p1 = The Inheritance Tax return needs to be made by an executor of the estate who is being named on the probate application, or who is intending to apply to be named as an administrator (if there was no will).
 
@@ -741,7 +741,7 @@ page.iht.application.overview.common.ifYouNeed = To continue your probate applic
 page.iht.application.overview.common.ifYouFind = If you find anything else in the estate
 page.iht.application.overview.common.p4 = You will only need to tell us if the value of those things increase the value of the estate over the threshold. There will be Inheritance Tax to pay.
 page.iht.application.overview.common.youWillNeedTo = You will need to
-page.iht.application.overview.common.tellHMRC = tell us about the estate by using an IHT400 form
+page.iht.application.overview.common.tellHMRC = tell us about the estate by using an Inheritance Tax 400 form
 page.iht.application.overview.common.needDetails = I need the IHT Identifier, Gross Estate Figure and Net Estate Figure
 page.iht.application.overview.common.p1 = You can apply for probate from the <a href="{0}">Wills and probate page.</a> These are the details you will need:
 
@@ -1480,7 +1480,7 @@ page.iht.application.exemptions.guidance.increasing.threshold.section2.bullet3 =
 page.iht.application.exemptions.guidance.increasing.threshold.section2.bullet4 = a registered charity or other qualifying body like a sports club
 page.iht.application.exemptions.guidance.increasing.threshold.section2.p4 = This means you will only need to show HMRC that the net estate value is below the threshold. The estate’s exemptions, debts and mortgages will be subtracted from the value of the estate before it’s checked against the threshold. The gross value of the estate must be less than £1 million.
 page.iht.application.exemptions.guidance.increasing.threshold.section2.p5.start = If there are no exemptions, the debts cannot be subtracted at this stage. You will have to submit an
-page.iht.application.exemptions.guidance.increasing.threshold.section2.p5.link = IHT400 form
+page.iht.application.exemptions.guidance.increasing.threshold.section2.p5.link = Inheritance Tax 400 form
 page.iht.application.exemptions.guidance.increasing.threshold.section2.p5.end = simply because the gross value of the estate exceeds the threshold.
 
 page.iht.application.exemptions.guidance.increasing.threshold.section3.raisedHeader = If the threshold can be raised
@@ -2327,7 +2327,7 @@ iht.iv.signIn = Sign in
 page.iht.iv.failure.cannotConfirmIdentity = We cannot confirm who you are
 page.iht.iv.failure.tryAgainOr = You can try again or:
 page.iht.iv.failure.youCanAlso = You can also:
-page.iht.iv.failure.reportWithPaperForm = report the estate value using the <a id="paperFormLink" href="{0}">IHT205 paper form</a> instead
+page.iht.iv.failure.reportWithPaperForm = report the estate value using the <a id="paperFormLink" href="{0}">Inheritance Tax 205 form – (paper version)</a> instead
 page.iht.iv.failure.askForHelp = ask for help by email using ‘Get help with this page’ below
 
 page.iht.iv.failure.failedMatching.failureReason = The information you have provided does not match what we hold.
@@ -2343,7 +2343,7 @@ page.iht.iv.failure.incomplete.heading = Sorry, there was a problem with the ser
 
 page.iht.iv.failure.preconditionFailed.heading = You cannot use this service
 page.iht.iv.failure.preconditionFailed.failureReason = HMRC cannot confirm your identity from the information you gave.
-page.iht.iv.failure.preconditionFailed.usePaperForm = Use the <a id="paperFormLink" href="{0}">IHT205 paper form</a> to report the estate value instead.
+page.iht.iv.failure.preconditionFailed.usePaperForm = Use the <a id="paperFormLink" href="{0}">Inheritance Tax 205 form – (paper version)</a> to report the estate value instead.
 
 page.iht.iv.failure.userAborted.failureReason = You have not given us enough information.
 
@@ -2355,12 +2355,12 @@ page.iht.iv.failure.2fa.p1 = You need to set up 2-step verification so you can s
 
 error.registration.serviceUnavailable.p1 = Wait a few seconds and try again.
 error.registration.serviceUnavailable.p2 = If you see this message several times, you will need to sign out and register again later at <a id="registrationChecklistLink" href="{0}">https://www.tax.service.gov.uk/inheritance-tax/registration/registration-checklist</a> (save this link).
-error.registration.serviceUnavailable.p3 = You can choose to report the estate value using the <a id="paperFormLink"  href="{0}">IHT205 paper form</a> instead.
+error.registration.serviceUnavailable.p3 = You can choose to report the estate value using the <a id="paperFormLink"  href="{0}">Inheritance Tax 205 form – (paper version)</a> instead.
 
 error.estateReport.serviceUnavailable.p3 = If you see this message several times you can sign out now and try again later to submit your report at <a id="declarationLink" href="{0}">https://www.tax.service.gov.uk/inheritance-tax/estate-report/declaration</a> (save this link).
 
 error.estateOverview.jsonError.p1 = You cannot complete your estate report online. This is because of an error in our system.
-error.estateOverview.jsonError.p2 = Use the <a id="paperFormLink" href="{0}">IHT205 paper form</a> to report the estate value.
+error.estateOverview.jsonError.p2 = Use the <a id="paperFormLink" href="{0}">Inheritance Tax 205 form – (paper version)</a> to report the estate value.
 
 error.application.systemError.p1 = Try again later to sign in to the service at <a id="estateReportLink" href="{0}">https://www.tax.service.gov.uk/inheritance-tax/estate-report</a> (save this link).
 error.registration.systemError.p1 = Try again later to sign in to the service at <a id="checklistLink" href="{0}">https://www.tax.service.gov.uk/inheritance-tax/registration/registration-checklist</a> (save this link).
@@ -2368,7 +2368,7 @@ error.registration.systemError.p1 = Try again later to sign in to the service at
 
 #New IV Error Content
 page.iht.iv.failure.couldNotConfirmIdentity=We could not confirm your identity
-page.iht.iv.failure.youCanReport=You can report the estate value using the <a id="paperFormLink" href="{0}">IHT205 paper form</a> instead.
+page.iht.iv.failure.youCanReport=You can report the estate value using the <a id="paperFormLink" href="{0}">Inheritance Tax 205 form – (paper version)</a> instead.
 page.iht.iv.failure.ifYouThink=If you still think you have an answer for any of the questions, you can try again.
 page.iht.iv.failure.lockedOutTryAgain=If you want to try again please wait 24 hours then try to sign in at <a id="try-again" href="{0}">https://www.tax.service.gov.uk{0}</a>.
 page.iht.iv.failure.helpWithConfirm=Help with confirming your identity
@@ -2430,7 +2430,7 @@ global.error.pageNotFound404.message=Please check that you have entered the corr
 global.error.InternalServerError500.title = Sorry, there is a problem with the service
 global.error.InternalServerError500.heading = Sorry, we are experiencing technical difficulties
 global.error.InternalServerError500.message = Please try again in a few moments.
-global.error.InternalServerError500.message1 = If you see this message several times, you can choose to report the estate value using the <a id="paperFormLink" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459092/IHT205_2011_.pdf">IHT205 paper form</a> instead.
+global.error.InternalServerError500.message1 = If you see this message several times, you can choose to report the estate value using the <a id="paperFormLink" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/459092/IHT205_2011_.pdf">Inheritance Tax 205 form – (paper version)</a> instead.
 
 
 # end of frontend-bootstrap error messages
@@ -2698,5 +2698,3 @@ page.iht.application.overview.closed.viewClearanceCertificate = View this estate
 page.iht.application.overview.closed.p1 = This certificate confirms that we will not make any future tax claims on the estate based on the details you have given in the estate report.
 
 page.iht.questionnaire.intendReturn.question=Do you intend to come back later to complete your estate report?
-
-

--- a/test/iht/testhelpers/UseService.scala
+++ b/test/iht/testhelpers/UseService.scala
@@ -18,7 +18,7 @@ package iht.testhelpers
 
 trait UseService {
 
-  val pageIHTFilterUseServiceBetween325000And1MillionParagraph0   = "If the gross value of the estate (ie the value before you subtract debts and mortgages) is between £325,000 and £1 million, you may have to use the IHT400 form to report the estate value."
+  val pageIHTFilterUseServiceBetween325000And1MillionParagraph0   = "If the gross value of the estate (ie the value before you subtract debts and mortgages) is between £325,000 and £1 million, you may have to use the Inheritance Tax 400 form to report the estate value."
   val pageIHTFilterUseServiceBetween325000And1MillionIHTFormlink  = "IHT400 form"
   val pageIHTFilterUseServiceBetween325000And1MillionSection4P1   = "You’ll be asked to log in to confirm who you are with HMRC."
   val pageIHTFilterUseServiceBetween325000And1MillionReport       = "Continue to the online service"

--- a/test/iht/views/IhtErrorTemplateViewTest.scala
+++ b/test/iht/views/IhtErrorTemplateViewTest.scala
@@ -22,7 +22,7 @@ class IhtErrorTemplateViewTest extends ViewTestHelper {
   val title = "Sorry, there is a problem with the service"
   val messages1 = "Try again later to sign in to the service at https://www.tax.service.gov.uk/inheritance-tax/estate-report (save this link)."
   val messages2 = "We saved your progress on the estate report."
-  val messages3 = "If you see this message several times, you can choose to report the estate value using the IHT205 paper form instead."
+  val messages3 = "If you see this message several times, you can choose to report the estate value using the Inheritance Tax 205 form – (paper version) instead."
   lazy val ihtErrorTemplateView: iht_error_template = app.injector.instanceOf[iht_error_template]
   def view: String = ihtErrorTemplateView()(createFakeRequest(), messages).toString
 

--- a/test/iht/views/filter/DomicileViewTest.scala
+++ b/test/iht/views/filter/DomicileViewTest.scala
@@ -110,8 +110,8 @@ class DomicileViewTest extends ViewTestHelper {
       val result = domicileView(fakeForm)(fakeRequest, applicationMessages)
       val doc = asDocument(contentAsString(result))
 
-      val link = doc.getElementById("return-link")
-      link.text() must be(messagesApi("page.iht.filter.domicile.return.link"))
+      val link = doc.getElementById("back-button")
+      link.text() must be(messagesApi("iht.back"))
       link.attr("href") must be(iht.controllers.filter.routes.FilterController.onPageLoad().url)
     }
   }

--- a/test/iht/views/helpers/MessagesHelper.scala
+++ b/test/iht/views/helpers/MessagesHelper.scala
@@ -22,20 +22,20 @@ trait MessagesHelper {
   val errorApplicationSystemErrorp1 = "Try again later to sign in to the service at https://www.tax.service.gov.uk/inheritance-tax/estate-report (save this link)."
   val ihtApplicationTimeoutp1 = "We saved your progress on the estate report."
   val pageIhtIVFailureYouCanAlso = "You can also:"
-  val pageIhtIVFailureReportWithPaperForm = "report the estate value using the IHT205 paper form instead"
+  val pageIhtIVFailureReportWithPaperForm = "report the estate value using the Inheritance Tax 205 form – (paper version) instead"
   val pageIhtIVFailureaskForHelp = "ask for help by email using ‘Get help with this page’ below"
 
   val errorRegistrationSystemErrorp1 = "Try again later to sign in to the service at https://www.tax.service.gov.uk/inheritance-tax/registration/registration-checklist (save this link)."
 
   val errorEstateOverviewJsonErrorp1 = "You cannot complete your estate report online. This is because of an error in our system."
-  val errorEstateOverviewJsonErrorp2 = "Use the IHT205 paper form to report the estate value."
+  val errorEstateOverviewJsonErrorp2 = "Use the Inheritance Tax 205 form – (paper version) to report the estate value."
 
   val errorRegistrationServiceUnavailablep1 = "Wait a few seconds and try again."
   val errorEstateReportServiceUnavailablep3 = "If you see this message several times you can sign out now and try again later to submit your report at https://www.tax.service.gov.uk/inheritance-tax/estate-report/declaration (save this link)."
 
 
   val errorRegistrationServiceUnavailablep2 = "If you see this message several times, you will need to sign out and register again later at https://www.tax.service.gov.uk/inheritance-tax/registration/registration-checklist (save this link)."
-  val errorRegistrationServiceUnavailablep3 = "You can choose to report the estate value using the IHT205 paper form instead."
+  val errorRegistrationServiceUnavailablep3 = "You can choose to report the estate value using the Inheritance Tax 205 form – (paper version) instead."
   val ihtIVTryAgain = "Try again"
   val ihtIVTryAgainLink = "/inheritance-tax/registration/check-your-answers"
 


### PR DESCRIPTION
Expanded on abbreviations used through the service for IHT400 & IHT205 & paper version as for accessibility requirements links must make sense out of context & abbreviation isn't as well known. Included welsh translations.
Changed the back button to meet govuk design standards. 
Updated unit tests so they all pass.

Before for links:
![Screenshot 2022-01-18 at 13 45 31](https://user-images.githubusercontent.com/61423748/150995724-3f0de067-baee-4a8e-b0e1-acd79c715f48.png)

After for links: 
<img width="745" alt="Screenshot 2022-01-25 at 14 17 22" src="https://user-images.githubusercontent.com/61423748/150995773-145dab28-4716-481f-aab4-f1de6d16f8ce.png">

Before back button:
![Screenshot 2022-01-18 at 14 39 28](https://user-images.githubusercontent.com/61423748/150995974-7e3e2194-5290-41b0-a859-bb96949fa2ac.png)

After for back button:
<img width="1053" alt="Screenshot 2022-01-25 at 10 27 26" src="https://user-images.githubusercontent.com/61423748/150996022-d49d12bc-18b0-4902-a587-b59e64cb37bd.png">

