### PR TITLE
DL-7100 updated presentation of info and fixed tests

### DIFF
--- a/app/assets/stylesheets/partials/_tables.scss
+++ b/app/assets/stylesheets/partials/_tables.scss
@@ -87,6 +87,10 @@ table th {
     font-weight: 700;
 }
 
+table tbody th {
+    font-weight: 400;
+}
+
 @media (min-width: 641px) {
     table th, table td {
         font-size: 16px;

--- a/app/iht/views/application/asset/assets_overview.scala.html
+++ b/app/iht/views/application/asset/assets_overview.scala.html
@@ -55,7 +55,7 @@ isFullWidth=false) {
 <p id="assets-guidance1">@Html(Messages("page.iht.application.assets.overview.guidance1", nameHelper(deceasedName)))</p>
 <p id="assets-guidance2">@Messages("iht.estateReport.completeEverySection")</p>
 
-<ul id="overview-table" class="tabular-data tabular-data--list">
+<dl id="overview-table" class="tabular-data tabular-data--list">
 
     @defining(appDetails.isCompleteProperties) { isComplete =>
         @genericOverviewItem(Messages("iht.estateReport.assets.propertiesBuildingsAndLand"),
@@ -393,7 +393,7 @@ isFullWidth=false) {
         )
     }
 
-</ul>
+</dl>
 
 <section class="subsection">
     <div id="total-row" class="grid-layout grid-layout--stacked grid-layout--nogutter">

--- a/app/iht/views/application/asset/properties/properties_overview.scala.html
+++ b/app/iht/views/application/asset/properties/properties_overview.scala.html
@@ -46,7 +46,7 @@ isFullWidth=false
 
 
 <div id="property-table" class="form-group" @if(propertyList.isEmpty){}>
-        <ul class="tabular-data tabular-data--list">
+        <dl class="tabular-data tabular-data--list">
         @genericOverviewTableItem(id = appConfig.AssetsPropertiesOwnedID,
             questionText = Messages("page.iht.application.assets.properties.question.question",
                                       DeceasedInfoHelper.getDeceasedNameOrDefaultString(registrationDetails, true)),
@@ -59,51 +59,62 @@ isFullWidth=false
                 case None => Messages("page.iht.application.assets.properties.question.noValue")
             }
         )
-        </ul>
+        </dl>
 
-        <section>
-         @if(propertyList.isEmpty){
-          <p id="properties-empty-table-row">@Messages("page.iht.application.assets.deceased-permanent-home.table.emptyRow.text")</p>
-          }else{
-          <ul id="properties" class="tabular-data tabular-data--list">
-          @for((element,i) <- propertyList.zipWithIndex){
-            <li class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-                <div class="tabular-data__data tabular-data__data--4-12">
-                    <div class="visually-hidden">@Messages("page.iht.application.assets.property.address.property.number", (i + 1))</div>
+    <section>
+        @if(propertyList.isEmpty){
+        <p id="properties-empty-table-row">@Messages("page.iht.application.assets.deceased-permanent-home.table.emptyRow.text")</p>
+        }else{
+            @for((element,i) <- propertyList.zipWithIndex){
+        <table id="properties" class="tabular-data tabular-data--list">
+            <caption class="heading-small">@Messages("page.iht.application.assets.property.address.property.number", (i + 1))</caption>
+            <thead>
+            <tr>
+                <th scope="col" class="visually-hidden">Property address</th>
+                <th scope="col" class="visually-hidden">Property value</th>
+                <th scope="col" class="visually-hidden">Delete property</th>
+                <th scope="col" class="visually-hidden">Change property</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <th scope="row" id="property-address-text">
                     @element.address match{
-                        case Some(x) => {
-                            @AddressHelper.addressLayout(x)
-                        }
-                        case None => {@Messages("page.iht.application.assets.deceased-permanent-home.table.emptyAddress.text")}
+                    case Some(x) => {
+                    @AddressHelper.addressLayout(x)
                     }
-                </div>
-                <div class="tabular-data__data tabular-data__data--4-12 u-align--tablet-right">
+                    case None => {@Messages("page.iht.application.assets.deceased-permanent-home.table.emptyAddress.text")}
+                    }
+                </th>
+
+                <td>
                     <span class="js-propertyValInput js-toFormat">@element.value.map(x=> "£"+CommonHelper.numberWithCommas(x))</span>
-                </div>
-                <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+                </td>
+                <td class="numeric">
                     <a href='@iht.controllers.application.assets.properties.routes.DeletePropertyController.onPageLoad(element.id.getOrElse("")).url' id='@appConfig.AssetsPropertiesDeleteID@element.id.getOrElse("")'>
-                        <span aria-hidden="true">
-                        @Messages("iht.delete")
-                        </span>
+                                <span aria-hidden="true">
+                                @Messages("iht.delete")
+                                </span>
                         <span class="visually-hidden">@Messages("page.iht.application.assets.property.address.property.delete", (i + 1))</span>
                     </a>
-                </div>
-                <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+                </td>
+                <td class="numeric">
                     <a href='@iht.controllers.application.assets.properties.routes.PropertyDetailsOverviewController.onEditPageLoad(element.id.getOrElse("")).url' id='@appConfig.AssetsPropertiesChangeID@element.id.getOrElse("")'>
                         @if(element.isComplete) {
-                            <span aria-hidden="true">@Messages("iht.change")</span>
-                            <span class="visually-hidden">@Messages("page.iht.application.assets.property.address.property.change", (i + 1))</span>
+                        <span aria-hidden="true">@Messages("iht.change")</span>
+                        <span class="visually-hidden">@Messages("page.iht.application.assets.property.address.property.change", (i + 1))</span>
                         } else {
-                            <span aria-hidden="true">@Messages("site.link.giveDetails")</span>
-                            <span class="visually-hidden">@Messages("page.iht.application.assets.property.address.property.givedetails", (i + 1))</span>
+                        <span aria-hidden="true">@Messages("site.link.giveDetails")</span>
+                        <span class="visually-hidden">@Messages("page.iht.application.assets.property.address.property.givedetails", (i + 1))</span>
                         }
                     </a>
-                </div>
-            </li>
-          }
-          </ul>
-          }
-        </section>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        }
+        }
+    </section>
 </div>
 
 

--- a/app/iht/views/application/asset/properties/property_details_overview.scala.html
+++ b/app/iht/views/application/asset/properties/property_details_overview.scala.html
@@ -54,20 +54,20 @@ browserTitle = Some(Messages("iht.estateReport.assets.propertyAdd")),
 isFullWidth = false) {
 
 <div class="form-group">
-    <ul id="property-details-table" class="tabular-data tabular-data--list">
+    <dl id="property-details-table" class="tabular-data tabular-data--list">
         @defining(property.flatMap(_.id))  { propertyId =>
             @defining(property.flatMap(_.address))  { propertyAddress =>
-                <li id="property-address-question" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-                    <div class="tabular-data__data tabular-data__data--6-12">@Messages("iht.estateReport.assets.property.whatIsAddress.question")</div>
-                    <div class="tabular-data__data tabular-data__data--4-12">
+                <div id="property-address-question" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+                    <dt class="tabular-data__data tabular-data__data--6-12">@Messages("iht.estateReport.assets.property.whatIsAddress.question")</dt>
+                    <dd class="tabular-data__data tabular-data__data--4-12">
                         @propertyAddress match{
                             case Some(x) => {
                                 @AddressHelper.addressLayout(x)
                             }
                             case None => {}
                         }
-                    </div>
-                    <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+                    </dd>
+                    <dd class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
                         <a id="@appConfig.AssetsPropertiesPropertyAddressID" href='@{propertyId match{
                                     case Some(id) => PropertyAddressController.onEditPageLoad(id)
                                     case None => PropertyAddressController.onPageLoad()
@@ -78,19 +78,19 @@ isFullWidth = false) {
                                 Messages("page.iht.application.assets.property.detailsOverview.address.screenReader.link.change"),
                                 Messages("page.iht.application.assets.property.detailsOverview.address.screenReader.link.noValue"))
                         </a>
-                    </div>
-                </li>
+                    </dd>
+                </div>
             }
             @defining(property.flatMap(_.propertyType))  { propertyType =>
-                <li id="kind-of-property-question" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-                    <div class="tabular-data__data tabular-data__data--6-12">@Messages("iht.estateReport.assets.properties.whatKind.question")</div>
-                    <div class="tabular-data__data tabular-data__data--4-12">
+                <div id="kind-of-property-question" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+                    <dt class="tabular-data__data tabular-data__data--6-12">@Messages("iht.estateReport.assets.properties.whatKind.question")</dt>
+                    <dd class="tabular-data__data tabular-data__data--4-12">
                         @{propertyType match {
                         case Some(x) => {FieldMappings.propertyType(messages, appConfig)(x)}
                         case None => {}
                         }}
-                    </div>
-                    <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+                    </dd>
+                    <dd class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
                         <a id = "@appConfig.AssetsPropertiesPropertyKindID" href='@{propertyId match{
                                     case Some(id) => PropertyTypeController.onEditPageLoad(id)
                                     case None => PropertyTypeController.onPageLoad()
@@ -101,19 +101,19 @@ isFullWidth = false) {
                                 Messages("page.iht.application.assets.property.detailsOverview.kindOfProperty.screenReader.link.change"),
                                 Messages("page.iht.application.assets.property.detailsOverview.kindOfProperty.screenReader.link.noValue"))
                         </a>
-                    </div>
-                </li>
+                    </dd>
+                </div>
             }
             @defining(property.flatMap(_.typeOfOwnership))  { typeOfOwnership =>
-                <li id="type-of-ownership-question" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-                    <div class="tabular-data__data tabular-data__data--6-12">@Html(Messages("iht.estateReport.assets.howOwnedByDeceased", nameHelper(deceasedName)))</div>
-                    <div class="tabular-data__data tabular-data__data--4-12">
+                <div id="type-of-ownership-question" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+                    <dt class="tabular-data__data tabular-data__data--6-12">@Html(Messages("iht.estateReport.assets.howOwnedByDeceased", nameHelper(deceasedName)))</dt>
+                    <dd class="tabular-data__data tabular-data__data--4-12">
                         @{typeOfOwnership match {
                         case Some(x) => {FieldMappings.typesOfOwnership(deceasedName)(messages, appConfig)(x)._1}
                         case None => {}
                         }}
-                    </div>
-                    <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+                    </dd>
+                    <dd class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
                         <a id = "@appConfig.AssetsPropertiesPropertyOwnershipID" href='@{propertyId match{
                                         case Some(id) => PropertyOwnershipController.onEditPageLoad(id)
                                         case None => PropertyOwnershipController.onPageLoad()
@@ -124,19 +124,19 @@ isFullWidth = false) {
                                 Messages("page.iht.application.assets.property.detailsOverview.owned.screenReader.link.change", deceasedName),
                                 Messages("page.iht.application.assets.property.detailsOverview.owned.screenReader.link.noValue", deceasedName))
                         </a>
-                    </div>
-                </li>
+                    </dd>
+                </div>
             }
             @defining(property.flatMap(_.tenure)) { tenure =>
-                <li id="freehold-leasehold-question" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-                    <div class="tabular-data__data tabular-data__data--6-12">@Messages("iht.estateReport.assets.properties.freeholdOrLeasehold")</div>
-                    <div class="tabular-data__data tabular-data__data--4-12">
+                <div id="freehold-leasehold-question" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+                    <dt class="tabular-data__data tabular-data__data--6-12">@Messages("iht.estateReport.assets.properties.freeholdOrLeasehold")</dt>
+                    <dd class="tabular-data__data tabular-data__data--4-12">
                         @{tenure match {
                         case Some(x) => {FieldMappings.tenures(deceasedName)(messages, appConfig)(x)._1}
                         case None => {}
                         }}
-                    </div>
-                    <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+                    </dd>
+                    <dd class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
                         <a id="@appConfig.AssetsPropertiesTenureID" href='@{propertyId match{
                                         case Some(id) => PropertyTenureController.onEditPageLoad(id)
                                         case None => PropertyTenureController.onPageLoad()
@@ -147,19 +147,19 @@ isFullWidth = false) {
                                 Messages("page.iht.application.assets.property.detailsOverview.freeholdLeasehold.screenReader.link.change"),
                                 Messages("page.iht.application.assets.property.detailsOverview.freeholdLeasehold.screenReader.link.noValue"))
                         </a>
-                    </div>
-                </li>
+                    </dd>
+                </div>
             }
             @defining(property.flatMap(_.value)) { value =>
-                <li id="property-value-question" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-                    <div class="tabular-data__data tabular-data__data--6-12">@Html(Messages("iht.estateReport.assets.properties.value.question", nameHelper(deceasedName)))</div>
-                    <div class="tabular-data__data tabular-data__data--4-12">
+                <div id="property-value-question" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+                    <dt class="tabular-data__data tabular-data__data--6-12">@Html(Messages("iht.estateReport.assets.properties.value.question", nameHelper(deceasedName)))</dt>
+                    <dd class="tabular-data__data tabular-data__data--4-12">
                         @{value match {
                         case Some(x) => {"£" + CommonHelper.numberWithCommas(x)}
                         case None => {}
                         }}
-                    </div>
-                    <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+                    </dd>
+                    <dd class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
                         <a id="@appConfig.AssetsPropertiesPropertyValueID" href='@{propertyId match{
                                         case Some(id) => PropertyValueController.onEditPageLoad(id)
                                         case None => PropertyValueController.onPageLoad()
@@ -171,11 +171,11 @@ isFullWidth = false) {
                                 Messages("page.iht.application.assets.property.detailsOverview.value.screenReader.link.noValue"),
                                 currencyValue = true)
                         </a>
-                    </div>
-                </li>
+                    </dd>
+                </div>
             }
         }
-    </ul>
+    </dl>
 </div>
 
 <div class="panel panel-border-wide">

--- a/app/iht/views/application/asset/trusts/trusts_overview.scala.html
+++ b/app/iht/views/application/asset/trusts/trusts_overview.scala.html
@@ -52,7 +52,7 @@ isFullWidth=false
 
 
     <section id="trusts-section" class="form-group">
-        <ul>
+        <dl>
             @{
                 genericOverviewTableItem(id = appConfig.AssetsTrustsBenefitedID,
                     questionText = Messages("iht.estateReport.assets.trusts.question",deceasedName),
@@ -94,7 +94,7 @@ isFullWidth=false
                         Messages("page.iht.application.assets.trusts.value.screenreader.link.noValue"))
                 )
             }
-        </ul>
+        </dl>
     </section>
 
     @returnLink(

--- a/app/iht/views/application/debts/debts_overview.scala.html
+++ b/app/iht/views/application/debts/debts_overview.scala.html
@@ -56,7 +56,7 @@ isFullWidth=false) {
 </div>
 
 <div id="table-overview" class="form-group">
-    <ul class="tabular-data tabular-data--list">
+    <dl class="tabular-data tabular-data--list">
     @defining(appDetails.isCompleteMortgages) { isComplete =>
         @genericOverviewItem(Messages("iht.estateReport.debts.mortgages"),
             "mortgages", appConfig.DebtsMortgagesID,
@@ -210,7 +210,7 @@ isFullWidth=false) {
         classValueCell = "u-align--tablet-right"
         )
     }
-    </ul>
+    </dl>
     <section class="subsection">
         <div id="total-row" class="grid-layout grid-layout--stacked grid-layout--nogutter">
             <div class="grid-layout__column grid-layout__column--4-12">

--- a/app/iht/views/application/debts/mortgages_overview.scala.html
+++ b/app/iht/views/application/debts/mortgages_overview.scala.html
@@ -56,10 +56,10 @@ isFullWidth= false) {
 
         <section id="property-table" class="form-group">
             <h2 class="visually-hidden" id="properties-header">@Messages("page.iht.application.assets.deceased-permanent-home.table.header")</h2>
-            <ul id="properties" class="tabular-data tabular-data--list">
+            <dl id="properties" class="tabular-data tabular-data--list">
             @for((element,i) <- propertyList.zipWithIndex){
-                <li class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-                      <div class="tabular-data__data tabular-data__data--6-12">
+                <div class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+                      <dt class="tabular-data__data tabular-data__data--6-12">
                           @element.address match{
                               case Some(x) => {
                                 @AddressHelper.addressLayout(x)
@@ -67,8 +67,8 @@ isFullWidth= false) {
                               case None => {@Messages("page.iht.application.assets.deceased-permanent-home.table.emptyAddress.text")}
                           }
 
-                        </div>
-                        <div class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right">
+                        </dt>
+                        <dd class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right">
                             @defining(mortgageList.find(_.id equals element.id.getOrElse(""))) { mortgage =>
                               @mortgage.map(
                                mort => mort.isOwned match{
@@ -78,8 +78,8 @@ isFullWidth= false) {
                                             }
                                      )
                             }
-                        </div>
-                        <div class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right">
+                        </dd>
+                        <dd class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right">
                             <a href='@iht.controllers.application.debts.routes.MortgageValueController.onPageLoad(element.id.getOrElse("")).url' id='@appConfig.DebtsMortgagesPropertyID@element.id.getOrElse("")'>
 
 
@@ -110,10 +110,10 @@ isFullWidth= false) {
                                }
                              }
                             </a>
-                        </div>
-                </li>
+                        </dd>
+                </div>
                }
-            </ul>
+            </dl>
           </section>
 
     }

--- a/app/iht/views/application/exemption/charity/charities_overview.scala.html
+++ b/app/iht/views/application/exemption/charity/charities_overview.scala.html
@@ -39,7 +39,7 @@ isFullWidth=false
 ) {
 
     <section id="charity-table">
-        <ul>
+        <dl>
         @genericOverviewTableItem(id = appConfig.ExemptionsCharitiesAssetsID,
         questionText = Messages("iht.estateReport.exemptions.charities.assetLeftToCharity.question",
                                 DeceasedInfoHelper.getDeceasedNameOrDefaultString(registrationDetails, true)),
@@ -49,21 +49,21 @@ isFullWidth=false
         link = Some(iht.controllers.application.exemptions.charity.routes.AssetsLeftToCharityQuestionController.onPageLoad),
         linkScreenReader = Messages("page.iht.application.exemptions.charityOverview.questionLabel.screenreader.link.value",
             DeceasedInfoHelper.getDeceasedNameOrDefaultString(registrationDetails, true)))
-        </ul>
+        </dl>
 
         <div class="subsection">
           <h2>@Messages("page.iht.application.exemptions.charityOverviewTable.header")</h2>
-          <ul id="charities_table" class="tabular-data tabular-data--list">
+          <dl id="charities_table" class="tabular-data tabular-data--list">
           @for((element,i) <- charities.zipWithIndex){
-          <li class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-              <div class="tabular-data__data tabular-data__data--4-12">
+          <div class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+              <dt class="tabular-data__data tabular-data__data--4-12">
                   <span class="visually-hidden">@Messages("page.iht.application.exemptions.assetLeftToCharity.screenreader.ident", (i + 1)) </span>
                   @element.nameValidationMessage.fold(nameHelper(element.name))(message=>Html(message))
-              </div>
-              <div class="tabular-data__data tabular-data__data--4-12 u-align--tablet-right">
+              </dt>
+              <dd class="tabular-data__data tabular-data__data--4-12 u-align--tablet-right">
                   <span id="charity-total">@if(element.totalValue.isDefined){&pound;@CommonHelper.numberWithCommas(element.totalValue.getOrElse(BigDecimal(0)))}</span>
-              </div>
-              <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+              </dd>
+              <dd class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
                 <a href='@iht.controllers.application.exemptions.charity.routes.CharityDeleteConfirmController.onPageLoad(element.id.getOrElse("")).url'
                    id='@appConfig.ExemptionsCharitiesDeleteID@element.id.getOrElse("")'>
                     <span aria-hidden="true">@Messages("iht.delete")</span><span class="visually-hidden">@Messages("page.iht.application.charity.delete.screenReader", element.name match {
@@ -71,8 +71,8 @@ isFullWidth=false
                         case _ => {""}
                     }, (i + 1))</span>
                 </a>
-              </div>
-              <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+              </dd>
+              <dd class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
                   <a href='@iht.controllers.application.exemptions.charity.routes.CharityDetailsOverviewController.onEditPageLoad(element.id.getOrElse("")).url'
                      id='@appConfig.ExemptionsCharitiesChangeID@element.id.getOrElse("")'>
                       <span aria-hidden="true">@Messages("iht.change")</span><span class="visually-hidden">@Messages("page.iht.application.charity.edit.screenReader", element.name match {
@@ -80,10 +80,10 @@ isFullWidth=false
                           case _ => {""}
                       }, (i + 1))</span>
                   </a>
-              </div>
-          </li>
+              </dd>
+          </div>
           }
-        </ul>
+        </dl>
       </div>
     </section>
 

--- a/app/iht/views/application/exemption/charity/charity_details_overview.scala.html
+++ b/app/iht/views/application/exemption/charity/charity_details_overview.scala.html
@@ -43,7 +43,7 @@ browserTitle = Some(Messages("page.iht.application.exemptions.overview.charity.d
 isFullWidth = false) {
 
 <section>
-    <ul id="charity-details-table" class="tabular-data tabular-data--list">
+    <dl id="charity-details-table" class="tabular-data tabular-data--list">
     @defining(charity.flatMap(_.id))  { charityId =>
         @defining(charity.flatMap(_.name))  { charityName =>
                 @genericOverviewItem(
@@ -127,7 +127,7 @@ isFullWidth = false) {
                     classAllCells = "")
         }
     }
-    </ul>
+    </dl>
 
 </section>
 <p>

--- a/app/iht/views/application/exemption/exemptions_overview.scala.html
+++ b/app/iht/views/application/exemption/exemptions_overview.scala.html
@@ -56,7 +56,7 @@ headingName = deceasedName) {
 <p id="exemption-guidance2">@Messages("iht.estateReport.completeEverySection")</p>
 
 <section id="overview-table" class="form-group">
-    <ul class="tabular-data tabular-data--list">
+    <dl class="tabular-data tabular-data--list">
     @if(married) {
         @defining(exemptions.partner.flatMap(_.isComplete)) { isComplete =>
             @genericOverviewItem(
@@ -161,7 +161,7 @@ headingName = deceasedName) {
         classValueCell = "u-align--tablet-right"
         )
     }
-    </ul>
+    </dl>
     <div class="subsection">
         <div id="total-row" class="grid-layout grid-layout--stacked grid-layout--nogutter">
             <div class="grid-layout__column grid-layout__column--4-12">

--- a/app/iht/views/application/exemption/partner/partner_overview.scala.html
+++ b/app/iht/views/application/exemption/partner/partner_overview.scala.html
@@ -37,7 +37,7 @@ registrationDetails: RegistrationDetails)(implicit request:Request[_], messages:
 browserTitle = Some(Messages("page.iht.application.exemptions.partner.overview.browserTitle")),
 isFullWidth=false) {
     <section id="overview-table" class="section">
-        <ul id="partner-overview-table" class="tabular-data tabular-data--list">
+        <dl id="partner-overview-table" class="tabular-data tabular-data--list">
         @{
             defining(appDetails.allExemptions.flatMap(_.partner).flatMap(_.isAssetForDeceasedPartner).map(_=>true)) { isComplete =>
                 genericOverviewItem(
@@ -182,7 +182,7 @@ isFullWidth=false) {
                 )
             }
         }
-        </ul>
+        </dl>
     </section>
 
     @registrationDetails.deceasedDetails.map{ dd=>

--- a/app/iht/views/application/exemption/qualifyingBody/qualifying_bodies_overview.scala.html
+++ b/app/iht/views/application/exemption/qualifyingBody/qualifying_bodies_overview.scala.html
@@ -47,7 +47,7 @@ headingName = deceasedName
 @progressiveDisclosure(request.uri)
 
     <section id="qualifyingBody-table">
-        <ul class="tabular-data tabular-data--list">
+        <dl class="tabular-data tabular-data--list">
         @genericOverviewTableItem(id = appConfig.ExemptionsOtherAssetsID,
             questionText = Messages("page.iht.application.exemptions.qualifyingBodyOverview.question",
             DeceasedInfoHelper.getDeceasedNameOrDefaultString(registrationDetails, true)),
@@ -57,23 +57,23 @@ headingName = deceasedName
             answerValue= Messages(getDisplayValueForBoolean(isAssetLeftToQualifyingBody)),
             link = Some(iht.controllers.application.exemptions.qualifyingBody.routes.AssetsLeftToQualifyingBodyQuestionController.onPageLoad),
             linkScreenReader = Messages("page.iht.application.exemptions.qualifyingBodyOverview.question.screenreader.link", deceasedName))
-        </ul>
+        </dl>
         <div class="subsection">
         <h2>@Messages("page.iht.application.exemptions.qualifyingBodyOverviewTable.header")</h2>
-        <ul id="qualifying_bodies_table" class="tabular-data tabular-data--list">
+        <dl id="qualifying_bodies_table" class="tabular-data tabular-data--list">
         @for((element,i) <- qualifyingBodies.zipWithIndex){
-        <li class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-            <div class="tabular-data__data tabular-data__data--4-12">
+        <div class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+            <dt class="tabular-data__data tabular-data__data--4-12">
                 <span class="visually-hidden">@Messages("page.iht.application.exemptions.qualifyingBodyOverview.screenreader.ident", (i + 1)) </span>
                 @(element.name) match {
                     case (None) => { @Messages("iht.estateReport.exemptions.charities.noNameAdded") }
                     case (Some(name)) => { @nameHelper(name) }
                 }
-            </div>
-            <div class="tabular-data__data tabular-data__data--4-12 u-align--tablet-right">
+            </dt>
+            <dd class="tabular-data__data tabular-data__data--4-12 u-align--tablet-right">
                 <span id="qualifying-body-total">&pound;@CommonHelper.numberWithCommas(element.totalValue.getOrElse(BigDecimal(0)))</span>
-            </div>
-            <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+            </dd>
+            <dd class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
                 <a href="@iht.controllers.application.exemptions.qualifyingBody.routes.QualifyingBodyDeleteConfirmController.onPageLoad(element.id.getOrElse("")).url"
                 id="@appConfig.ExemptionsOtherDeleteID@element.id.getOrElse("")">
                 <span aria-hidden="true">@Messages("iht.delete")</span>
@@ -82,8 +82,8 @@ headingName = deceasedName
                         case _ => {""}
                     }, (i + 1))</span>
                 </a>
-            </div>
-            <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+            </dd>
+            <dd class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
                <a href="@iht.controllers.application.exemptions.qualifyingBody.routes.QualifyingBodyDetailsOverviewController.onEditPageLoad(element.id.getOrElse("")).url"
                id="@appConfig.ExemptionsOtherChangeID@element.id.getOrElse("")">
                 <span aria-hidden="true">@Messages("iht.change")</span>
@@ -92,10 +92,10 @@ headingName = deceasedName
                         case _ => {""}
                     }, (i + 1))</span>
                 </a>
-            </div>
-        </li>
+            </dd>
+        </div>
         }
-        </ul>
+        </dl>
       </div>
     </section>
 

--- a/app/iht/views/application/exemption/qualifyingBody/qualifying_body_details_overview.scala.html
+++ b/app/iht/views/application/exemption/qualifyingBody/qualifying_body_details_overview.scala.html
@@ -47,7 +47,7 @@ isFullWidth = false) {
 <p class="lede" id="qb-guidance-1">@Messages("iht.estateReport.exemptions.qualifyingBodies.assetsLeftToQualifyingBodyNotCharities")</p>
 
 <section>
-    <ul id="qualifying-body-details-table" class="tabular-data tabular-data--list">
+    <dl id="qualifying-body-details-table" class="tabular-data tabular-data--list">
     @defining(qualifyingBody.flatMap(_.id))  { qualifyingBodyId =>
 
         @defining(qualifyingBody.flatMap(_.name))  { qualifyingBodyName =>
@@ -108,7 +108,7 @@ isFullWidth = false) {
                     classAllCells = "")
         }
     }
-    </ul>
+    </dl>
 </section>
 <p>
 @returnLink(

--- a/app/iht/views/application/generic_overview.scala.html
+++ b/app/iht/views/application/generic_overview.scala.html
@@ -75,15 +75,15 @@ messagesFileBullets:Seq[String] = Seq.empty
     </div>
     }
 
-    <ul class="tabular-data tabular-data--list">
+    <dl class="tabular-data tabular-data--list">
     @section.details.map{detail=>
-      <li id="@{detail.id}" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-          <div class="tabular-data__data tabular-data__data--4-12" aria-hidden="true">@{Html(Messages(detail.title))}</div>
-          <div class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right" aria-hidden="true">
+      <div id="@{detail.id}" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+          <dt class="tabular-data__data tabular-data__data--4-12" aria-hidden="true">@{Html(Messages(detail.title))}</dt>
+          <dd class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right" aria-hidden="true">
               @Messages(detail.value)
-          </div>
+          </dd>
           @if(showStatus){
-              <div id="@{detail.id}-section-details-status" class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right" aria-hidden="true">
+              <dd id="@{detail.id}-section-details-status" class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right" aria-hidden="true">
                   @if(detail.status.nonEmpty){
                       @if(detail.status == messageNotStarted) {
                         <span class="progress-status progress-status--not-started"><span>@Messages("iht.notStarted")</span></span>
@@ -91,20 +91,20 @@ messagesFileBullets:Seq[String] = Seq.empty
                         <span class="progress-status progress-status--complete"><span>@Messages("iht.complete")</span></span>
                       }
                   }
-              </div>
+              </dd>
           }
 
-          <div class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
+          <dd class="tabular-data__data tabular-data__data--2-12 u-align--tablet-right">
             @if(detail.link.linkText.length>0){
               <a id='@{detail.linkId}' href="@detail.link.linkUrl">
                 <span aria-hidden="true">@Messages(detail.link.linkText)</span>
                 <span class="visually-hidden">@Messages(detail.link.linkTextAccessibility, DeceasedInfoHelper.getDeceasedNameOrDefaultString(registrationDetails), detail.value)</span>
             </a>
             }
-          </div>
-      </li>
+          </dd>
+      </div>
     }
-  </ul>
+  </dl>
 </section>
 }
 

--- a/app/iht/views/ihtHelpers/custom/generic_overview_item.scala.html
+++ b/app/iht/views/ihtHelpers/custom/generic_overview_item.scala.html
@@ -28,19 +28,19 @@ classValueCell: String = "",
 classAllCells: String = ""
 )
 
-<li class="tabular-data__entry tabular-data__entry--grouped divider--bottom" id="@id-section">
-    <div class="tabular-data__data tabular-data__data--4-12 @classAllCells">@Html(title)</div>
-    <div class="tabular-data__data tabular-data__data--3-12 @classValueCell @classAllCells">
+<div class="tabular-data__entry tabular-data__entry--grouped divider--bottom" id="@id-section">
+    <dt class="tabular-data__data tabular-data__data--4-12 @classAllCells">@Html(title)</dt>
+    <dd class="tabular-data__data tabular-data__data--3-12 @classValueCell @classAllCells">
         @Html(value)
-    </div>
+    </dd>
     @if(itemStatus!= Html("??")){
-    <div id="@id-status" class="tabular-data__data tabular-data__data--3-12 @classAllCells u-align--tablet-center">
+    <dd id="@id-status" class="tabular-data__data tabular-data__data--3-12 @classAllCells u-align--tablet-center">
         @itemStatus
-    </div>
+    </dd>
     }
-    <div class="tabular-data__data tabular-data__data--2-12 @classAllCells">
+    <dd class="tabular-data__data tabular-data__data--2-12 @classAllCells">
         <a id="@id" href="@link">
             @linkText
         </a>
-    </div>
-</li>
+    </dd>
+</div>

--- a/app/iht/views/ihtHelpers/custom/generic_overview_table_item.scala.html
+++ b/app/iht/views/ihtHelpers/custom/generic_overview_table_item.scala.html
@@ -26,14 +26,14 @@ answerValue:String = "",
 link:Option[Call] = None,
 linkScreenReader:String
 )(implicit messages: Messages)
-<li id="@id-block" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
-    <div id="@id-question" class="tabular-data__data tabular-data__data--6-12">@Html(questionText)</div>
-    <div id="@id-question-value" class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right">
+<div id="@id-block" class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+    <dt id="@id-question" class="tabular-data__data tabular-data__data--6-12">@Html(questionText)</dt>
+    <dd id="@id-question-value" class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right">
         @if(answerValue.nonEmpty){
         @answerValue
         }
-    </div>
-    <div class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right">
+    </dd>
+    <dd class="tabular-data__data tabular-data__data--3-12 u-align--tablet-right">
         <a id="@id" href="@link">
             @if(answerValue.nonEmpty) {
                 @questionCategory match {
@@ -75,5 +75,5 @@ linkScreenReader:String
               }
             }
         </a>
-    </div>
-</li>
+    </dd>
+</div>

--- a/app/iht/views/ihtHelpers/custom/generic_overview_table_section.scala.html
+++ b/app/iht/views/ihtHelpers/custom/generic_overview_table_section.scala.html
@@ -26,13 +26,13 @@ htmlQuestionValue: => Html)(implicit messages: Messages)
 
 <section id="@sectionId" class="form-group">
     @htmlQuestionTitle
-    <ul class="tabular-data tabular-data--list">
+    <dl class="tabular-data tabular-data--list">
     @{isQuestionsShown match {
         case Some(true) => {Html(htmlQuestion.toString + htmlQuestionValue.toString)}
         case Some(false) => {
             htmlQuestion}
         case None => {}
     }}
-  </ul>
+  </dl>
 
 </section>

--- a/app/iht/views/ihtHelpers/custom/summary_item.scala.html
+++ b/app/iht/views/ihtHelpers/custom/summary_item.scala.html
@@ -30,35 +30,35 @@
 
 
 
-<li class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
+<div class="tabular-data__entry tabular-data__entry--grouped divider--bottom">
     @if(isNested){
-        <h4 class="tabular-data__data tabular-data__data--4-12">
+        <dt class="tabular-data__data tabular-data__data--4-12">
             @if(dataScreenReaderText > ""){
                 <span aria-hidden="true">@Html(label.replace("\n", "<br/>"))</span>
                 <span class="visually-hidden">@dataScreenReaderText</span>
             } else {
                 @Html(label.replace("\n", "<br/>"))
             }
-        </h4>
+        </dt>
     } else {
-        <h3 class="tabular-data__data tabular-data__data--4-12">
+        <dt class="tabular-data__data tabular-data__data--4-12">
             @if(dataScreenReaderText > ""){
                 <span aria-hidden="true">@Html(label.replace("\n", "<br/>"))</span>
                 <span class="visually-hidden">@dataScreenReaderText</span>
             } else {
                 @Html(label.replace("\n", "<br/>"))
             }
-        </h3>
+        </dt>
     }
-    <div class="tabular-data__data tabular-data__data--6-12">
+    <dd class="tabular-data__data tabular-data__data--6-12">
         @Html(data.trim().replace("\n", "<br/>"))
-    </div>
-    <div class="tabular-data__data tabular-data__data--2-12">
+    </dd>
+    <dd class="tabular-data__data tabular-data__data--2-12">
       @if(hasChangeLink){
         <a href="@changeLink" id="@linkId">
           <span aria-hidden="true">@Messages("iht.change")</span>
           <span class="visually-hidden">@changeLinkHiddenText</span>
         </a>
       }
-    </div>
-</li>
+    </dd>
+</div>

--- a/app/iht/views/registration/executor/executor_overview.scala.html
+++ b/app/iht/views/registration/executor/executor_overview.scala.html
@@ -55,16 +55,34 @@
     </div>
   </div>
 
-  <ul>
       @for(coExecutor <- coExecutors) {
-      <li class="grid-layout grid-layout--maintain-width grid-layout--nogutter divider--bottom section">
-        <div id='executorName-@coExecutor.id.getOrElse("")' class="grid-layout__column grid-layout__column--1-2">@nameHelper(coExecutor.name.toString)</div>
-        <div class="grid-layout__column grid-layout__column--1-4 u-align--right"><a href='@iht.controllers.registration.executor.routes.DeleteCoExecutorController.onPageLoad(coExecutor.id.getOrElse("")).url' id='delete-executor-@coExecutor.id.getOrElse("")'><span aria-hidden="true">@Messages("iht.delete")</span><span class="visually-hidden">@Messages("page.iht.registration.executor-overview.executor.delete.screenReader", coExecutor.name)</span></a></div>
-        <div class="grid-layout__column grid-layout__column--1-4 u-align--right"><a href='@iht.controllers.registration.executor.routes.CoExecutorPersonalDetailsController.onPageLoad(coExecutor.id).url' id='change-executor-@coExecutor.id.getOrElse("")'><span aria-hidden="true">@Messages("iht.change")</span><span class="visually-hidden">@Messages("page.iht.registration.executor-overview.executor.change.screenReader", coExecutor.name)</span></a></div>
-      </li>
+<table class="tabular-data tabular-data--list grid-layout grid-layout--maintain-width grid-layout--nogutter divider--bottom section">
+    <caption class="heading-small visually-hidden">@Messages("iht.registration.othersApplyingForProbate")</caption>
+<thead>
+<tr>
+    <th scope="col" class="visually-hidden">Executor name</th>
+    <th scope="col" class="visually-hidden">Delete executor</th>
+    <th scope="col" class="visually-hidden">Change executor</th>
+</tr>
+</thead>
+    <tbody>
+    <tr>
+        <th scope="row" class="grid-layout__column grid-layout__column--1-2" id='executorName-@coExecutor.id.getOrElse("")'>@nameHelper(coExecutor.name.toString)</th>
+        <td class="numeric grid-layout__column grid-layout__column--1-4 u-align--right">
+            <a href='@iht.controllers.registration.executor.routes.DeleteCoExecutorController.onPageLoad(coExecutor.id.getOrElse("")).url' id='delete-executor-@coExecutor.id.getOrElse("")'>
+                <span aria-hidden="true">@Messages("iht.delete")</span><span class="visually-hidden">@Messages("page.iht.registration.executor-overview.executor.delete.screenReader", coExecutor.name)</span>
+            </a>
+        </td>
+        <td class="numeric grid-layout__column grid-layout__column--1-4 u-align--right">
+            <a href='@iht.controllers.registration.executor.routes.CoExecutorPersonalDetailsController.onPageLoad(coExecutor.id).url' id='change-executor-@coExecutor.id.getOrElse("")'>
+                <span aria-hidden="true">@Messages("iht.change")</span><span class="visually-hidden">@Messages("page.iht.registration.executor-overview.executor.change.screenReader", coExecutor.name)</span>
+            </a>
+        </td>
+    </tr>
+    </tbody>
+</table>
       }
-  </ul>
-
+</br>
   @if(coExecutors.length < appConfig.maximumAdditionalCoExecutors) {
     @defining( Messages("page.iht.registration.executor-overview.sectionName"))  { sectionName =>
       @defining( Messages("page.iht.registration.executor-overview.yesnoQuestion")) { legend =>

--- a/app/iht/views/registration/registration_summary.scala.html
+++ b/app/iht/views/registration/registration_summary.scala.html
@@ -45,7 +45,7 @@ role:String)(implicit request : Request[_], messages: Messages, lang : play.api.
 
     <section class="form-group">
         <h2>@Html(Messages("site.nameDetails", nameHelper(deceasedName).toString))</h2>
-        <ul class="tabular-data tabular-data--list">
+        <dl class="tabular-data tabular-data--list">
             @defining(CommonHelper.getOrException(registrationDetails.deceasedDetails, "Deceased Details could not be found")) { deceasedDetails=>
 
                 @summaryItem(
@@ -116,13 +116,13 @@ role:String)(implicit request : Request[_], messages: Messages, lang : play.api.
                     linkId="change-relationship-status"
                 )
             }
-        </ul>
+        </dl>
       </section>
 
 
       <section class="form-group">
         <h2>@Messages("page.iht.registration.registrationSummary.applicantTable.title")</h2>
-        <ul class="tabular-data tabular-data--list">
+        <dl class="tabular-data tabular-data--list">
             @defining( CommonHelper.getOrException(registrationDetails.applicantDetails, "Applicant Details could not be found") ) { applicantDetails=>
 
                 @summaryItem(
@@ -179,7 +179,7 @@ role:String)(implicit request : Request[_], messages: Messages, lang : play.api.
                     linkId="change-probate-location"
                 )
             }
-        </ul>
+        </dl>
       </section>
 
 

--- a/app/iht/views/registration/registration_summary_coexecutor_panel.scala.html
+++ b/app/iht/views/registration/registration_summary_coexecutor_panel.scala.html
@@ -60,7 +60,7 @@
                   <h3 class='heading-medium'>
                       @Html(Messages("site.nameDetails", execName))
                     </h3>
-                    <ul class="tabular-data tabular-data--list">
+                    <dl class="tabular-data tabular-data--list">
 
                     @summaryItem(
                         label = Messages("iht.name.upperCaseInitial"),
@@ -115,7 +115,7 @@
                         isNested = true
                     )
 
-                  </ul>
+                  </dl>
 
                 </section>
             }

--- a/test/iht/views/ViewTestHelper.scala
+++ b/test/iht/views/ViewTestHelper.scala
@@ -153,6 +153,36 @@ trait ViewTestHelper extends FakeIhtApp with MockitoSugar with TestUtils with Be
     listItems.get(rowNo).getElementsByTag("div").get(colNo)
   }
 
+  def divCell(doc:Document, tableId:String, colNo: Int, rowNo: Int) = {
+    val propertiesUl = doc.getElementById(tableId)
+    val listItems = propertiesUl.getElementsByTag("div")
+    listItems.get(rowNo).getElementsByClass("tabular-data__data").get(colNo)
+  }
+
+  def thCellProp1(doc:Document, tableId:String, colNo: Int, rowNo: Int) = {
+    val propertiesUl = doc.getElementById(tableId)
+    val listItems = propertiesUl.getElementsByTag("tbody")
+    listItems.get(rowNo).getElementsByTag("th").get(colNo)
+  }
+
+  def tdCellProp1(doc:Document, tableId:String, colNo: Int, rowNo: Int) = {
+    val propertiesUl = doc.getElementById(tableId)
+    val listItems = propertiesUl.getElementsByTag("tbody")
+    listItems.get(rowNo).getElementsByTag("td").get(colNo)
+  }
+
+  def thCellProp2(doc:Document, tableId:String, colNo: Int, rowNo: Int) = {
+    val propertiesUl = doc.getElementById(tableId).lastElementSibling()
+    val listItems = propertiesUl.getElementsByTag("tbody")
+    listItems.get(rowNo).getElementsByTag("th").get(colNo)
+  }
+
+  def tdCellProp2(doc:Document, tableId:String, colNo: Int, rowNo: Int) = {
+    val propertiesUl = doc.getElementsByClass("tabular-data--list").get(1)
+    val listItems = propertiesUl.getElementsByTag("tbody")
+    listItems.get(rowNo).getElementsByTag("td").get(colNo)
+  }
+
   def link(doc: => Document, anchorId: => String, href: => String, text: => String): Unit = {
     def anchor = doc.getElementById(anchorId)
     s"have a link with id $anchorId and correct target" in {

--- a/test/iht/views/application/assets/properties/PropertiesOverviewViewTest.scala
+++ b/test/iht/views/application/assets/properties/PropertiesOverviewViewTest.scala
@@ -57,17 +57,35 @@ class PropertiesOverviewViewTest extends GenericNonSubmittablePageBehaviour {
 
   def addressWithDeleteAndModify(rowNo: Int, expectedValue: String) = {
     s"show address number ${rowNo + 1}" in {
-      tableCell(doc, addressTableId, 0, rowNo).ownText mustBe expectedValue
+      thCellProp1(doc, addressTableId, 0, rowNo).ownText mustBe expectedValue
     }
 
     s"show address number ${rowNo + 1} delete link" in {
-      val deleteDiv = tableCell(doc, addressTableId, 3, rowNo)
+      val deleteDiv = tdCellProp1(doc, addressTableId, 1,  rowNo)
       val anchor = deleteDiv.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi("iht.delete")
     }
 
     s"show address number ${rowNo + 1} give details link" in {
-      val deleteDiv = tableCell(doc, addressTableId, 4, rowNo)
+      val deleteDiv = tdCellProp1(doc, addressTableId,2, rowNo)
+      val anchor = deleteDiv.getElementsByTag("a").first
+      getVisibleText(anchor) mustBe messagesApi("iht.change")
+    }
+  }
+
+  def addressWithDeleteAndModify2(rowNo: Int, expectedValue: String) = {
+    s"show address number 2" in {
+      thCellProp2(doc, addressTableId, 0, 0).ownText mustBe expectedValue
+    }
+
+    s"show address number 2 delete link" in {
+      val deleteDiv = tdCellProp2(doc, addressTableId, 1, rowNo)
+      val anchor = deleteDiv.getElementsByTag("a").first
+      getVisibleText(anchor) mustBe messagesApi("iht.delete")
+    }
+
+    s"show address number 2 give details link" in {
+      val deleteDiv = tdCellProp2(doc, addressTableId, 2, rowNo)
       val anchor = deleteDiv.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi("iht.change")
     }
@@ -94,7 +112,7 @@ class PropertiesOverviewViewTest extends GenericNonSubmittablePageBehaviour {
 
     behave like addressWithDeleteAndModify(0, formatAddressForDisplay(CommonBuilder.DefaultUkAddress))
 
-    behave like addressWithDeleteAndModify(1, formatAddressForDisplay(CommonBuilder.DefaultUkAddress2))
+    behave like addressWithDeleteAndModify2(0, formatAddressForDisplay(CommonBuilder.DefaultUkAddress2))
 
     "show you haven't added message when there are no properties" in {
       val view = propertiesOverviewView(List(),

--- a/test/iht/views/application/assets/properties/PropertyDetailsOverviewViewTest.scala
+++ b/test/iht/views/application/assets/properties/PropertyDetailsOverviewViewTest.scala
@@ -55,15 +55,15 @@ class PropertyDetailsOverviewViewTest extends GenericNonSubmittablePageBehaviour
 
   def propertyAttributeWithValueAndChange(rowNo: Int, expectedAttributeName: => String, expectedAttributeValue: => String) = {
     s"show attribute number ${rowNo + 1}" in {
-      tableCell(doc, propertyAttributesTableId, 0, rowNo).text mustBe expectedAttributeName
+      divCell(doc, propertyAttributesTableId, 0, rowNo).text mustBe expectedAttributeName
     }
 
     s"show attribute number ${rowNo + 1} value" in {
-      tableCell(doc, propertyAttributesTableId, 1, rowNo).text mustBe expectedAttributeValue
+      divCell(doc, propertyAttributesTableId, 1, rowNo).text mustBe expectedAttributeValue
     }
 
     s"show attribute number ${rowNo + 1} change link" in {
-      val changeDiv = tableCell(doc, propertyAttributesTableId, 2, rowNo)
+      val changeDiv = divCell(doc, propertyAttributesTableId, 2, rowNo)
       val anchor = changeDiv.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi("iht.change")
     }

--- a/test/iht/views/application/debts/MortgagesOverviewViewTest.scala
+++ b/test/iht/views/application/debts/MortgagesOverviewViewTest.scala
@@ -70,11 +70,11 @@ class MortgagesOverviewViewTest extends ApplicationPageBehaviour {
 
   def addressWithDeleteAndModify(rowNo: Int, expectedValue: String) = {
     s"show address number ${rowNo + 1}" in {
-      tableCell(doc, addressTableId, 0, rowNo).ownText mustBe expectedValue
+      divCell(doc, addressTableId, 0, rowNo).ownText mustBe expectedValue
     }
 
     s"show address number ${rowNo + 1} Give details link" in {
-      val deleteDiv = tableCell(doc, addressTableId, 2, rowNo)
+      val deleteDiv = divCell(doc, addressTableId, 2, rowNo)
       val anchor = deleteDiv.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi("site.link.giveDetails")
     }

--- a/test/iht/views/application/exemption/charity/CharitiesOverviewViewTest.scala
+++ b/test/iht/views/application/exemption/charity/CharitiesOverviewViewTest.scala
@@ -70,21 +70,21 @@ class CharitiesOverviewViewTest extends CharitiesOverviewViewBehaviour {
 
   def charityWithDeleteAndModify(rowNo: Int, expectedName: String, expectedValue: String) = {
     s"show charity number ${rowNo + 1} name" in {
-      tableCell(doc, charityTableId, 0, rowNo).ownText mustBe expectedName
+      divCell(doc, charityTableId, 0, rowNo).ownText mustBe expectedName
     }
 
     s"show charity number ${rowNo + 1} value" in {
-      tableCell(doc, charityTableId, 1, rowNo).text mustBe expectedValue
+      divCell(doc, charityTableId, 1, rowNo).text mustBe expectedValue
     }
 
     s"show charity number ${rowNo + 1} change link" in {
-      val div = tableCell(doc, charityTableId, 2, rowNo)
+      val div = divCell(doc, charityTableId, 2, rowNo)
       val anchor = div.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi("iht.delete")
     }
 
     s"show charity number ${rowNo + 1} delete link" in {
-      val div = tableCell(doc, charityTableId, 3, rowNo)
+      val div = divCell(doc, charityTableId, 3, rowNo)
       val anchor = div.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi("iht.change")
     }

--- a/test/iht/views/application/exemption/charity/CharityDetailsOverviewViewTest.scala
+++ b/test/iht/views/application/exemption/charity/CharityDetailsOverviewViewTest.scala
@@ -52,15 +52,15 @@ trait CharityDetailsOverviewViewBehaviour extends GenericNonSubmittablePageBehav
                                           expectedAttributeValue: => String,
                                           expectedLinkText: => String) = {
     s"show attribute number ${rowNo + 1} name" in {
-      tableCell(doc, propertyAttributesTableId, 0, rowNo).text mustBe expectedAttributeName
+      divCell(doc, propertyAttributesTableId, 0, rowNo).text mustBe expectedAttributeName
     }
 
     s"show attribute number ${rowNo + 1} value" in {
-      tableCell(doc, propertyAttributesTableId, 1, rowNo).text mustBe expectedAttributeValue
+      divCell(doc, propertyAttributesTableId, 1, rowNo).text mustBe expectedAttributeValue
     }
 
     s"show attribute number ${rowNo + 1} change link" in {
-      val changeDiv = tableCell(doc, propertyAttributesTableId, 2, rowNo)
+      val changeDiv = divCell(doc, propertyAttributesTableId, 2, rowNo)
       val anchor = changeDiv.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi(expectedLinkText)
     }

--- a/test/iht/views/application/exemption/partner/PartnerOverviewViewTest.scala
+++ b/test/iht/views/application/exemption/partner/PartnerOverviewViewTest.scala
@@ -64,15 +64,15 @@ trait PartnerOverviewViewBehaviour extends GenericNonSubmittablePageBehaviour {
                                           expectedAttributeValue: => String,
                                           expectedLinkText: => String) = {
     s"show attribute number ${rowNo + 1} name" in {
-      tableCell(doc, assetsLeftToSpouseAttributesTableId, 0, rowNo).text mustBe expectedAttributeName
+      divCell(doc, assetsLeftToSpouseAttributesTableId, 0, rowNo).text mustBe expectedAttributeName
     }
 
     s"show attribute number ${rowNo + 1} value" in {
-      tableCell(doc, assetsLeftToSpouseAttributesTableId, 1, rowNo).text mustBe expectedAttributeValue
+      divCell(doc, assetsLeftToSpouseAttributesTableId, 1, rowNo).text mustBe expectedAttributeValue
     }
 
     s"show attribute number ${rowNo + 1} change link" in {
-      val changeDiv = tableCell(doc, assetsLeftToSpouseAttributesTableId, 2, rowNo)
+      val changeDiv = divCell(doc, assetsLeftToSpouseAttributesTableId, 2, rowNo)
       val anchor = changeDiv.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi(expectedLinkText)
     }

--- a/test/iht/views/application/exemption/qualifyingBody/QualifyingBodiesOverviewViewTest.scala
+++ b/test/iht/views/application/exemption/qualifyingBody/QualifyingBodiesOverviewViewTest.scala
@@ -70,21 +70,21 @@ class QualifyingBodiesOverviewViewTest extends QualifyingBodiesOverviewViewBehav
 
   def qualifyingBodyWithDeleteAndModify(rowNo: Int, expectedName: String, expectedValue: String) = {
     s"show qualifyingBody number ${rowNo + 1} name" in {
-      tableCell(doc, qualifyingBodyTableId, 0, rowNo).ownText mustBe expectedName
+      divCell(doc, qualifyingBodyTableId, 0, rowNo).ownText mustBe expectedName
     }
 
     s"show qualifyingBody number ${rowNo + 1} value" in {
-      tableCell(doc, qualifyingBodyTableId, 1, rowNo).text mustBe expectedValue
+      divCell(doc, qualifyingBodyTableId, 1, rowNo).text mustBe expectedValue
     }
 
     s"show qualifyingBody number ${rowNo + 1} delete link" in {
-      val div = tableCell(doc, qualifyingBodyTableId, 2, rowNo)
+      val div = divCell(doc, qualifyingBodyTableId, 2, rowNo)
       val anchor = div.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi("iht.delete")
     }
 
     s"show qualifyingBody number ${rowNo + 1} change link" in {
-      val div = tableCell(doc, qualifyingBodyTableId, 3, rowNo)
+      val div = divCell(doc, qualifyingBodyTableId, 3, rowNo)
       val anchor = div.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi("iht.change")
     }

--- a/test/iht/views/application/exemption/qualifyingBody/QualifyingBodyDetailsOverviewViewTest.scala
+++ b/test/iht/views/application/exemption/qualifyingBody/QualifyingBodyDetailsOverviewViewTest.scala
@@ -54,15 +54,15 @@ trait QualifyingBodyDetailsOverviewViewBehaviour extends GenericNonSubmittablePa
                                           expectedAttributeValue: => String,
                                           expectedLinkText: => String) = {
     s"show attribute number ${rowNo + 1} name" in {
-      tableCell(doc, propertyAttributesTableId, 0, rowNo).text mustBe expectedAttributeName
+      divCell(doc, propertyAttributesTableId, 0, rowNo).text mustBe expectedAttributeName
     }
 
     s"show attribute number ${rowNo + 1} value" in {
-      tableCell(doc, propertyAttributesTableId, 1, rowNo).text mustBe expectedAttributeValue
+      divCell(doc, propertyAttributesTableId, 1, rowNo).text mustBe expectedAttributeValue
     }
 
     s"show attribute number ${rowNo + 1} change link" in {
-      val changeDiv = tableCell(doc, propertyAttributesTableId, 2, rowNo)
+      val changeDiv = divCell(doc, propertyAttributesTableId, 2, rowNo)
       val anchor = changeDiv.getElementsByTag("a").first
       getVisibleText(anchor) mustBe messagesApi(expectedLinkText)
     }

--- a/test/iht/views/helpers/GenericOverviewHelper.scala
+++ b/test/iht/views/helpers/GenericOverviewHelper.scala
@@ -40,9 +40,10 @@ trait GenericOverviewHelper extends ViewTestHelper {
 
   def rowShouldBeAnswered(doc: Document, elementId: String, message: String, value: String, linkMessageKey: String, url: String) = {
     val li = doc.getElementById(elementId)
-    val divs = li.getElementsByTag("div")
-    divs.get(0).text mustBe message
-    divs.get(1).text mustBe value
+    val dt = li.getElementsByTag("dt")
+    val dd = li.getElementsByTag("dd")
+    dt.get(0).text mustBe message
+    dd.get(0).text mustBe value
 
     val link = li.getElementsByTag("a").get(0)
     messagesShouldBePresent(link.text, messagesApi(linkMessageKey))
@@ -52,9 +53,10 @@ trait GenericOverviewHelper extends ViewTestHelper {
 
   def rowShouldBeUnAnswered(doc: Document, elementId: String, messageKey: String, linkMessageKey: String, url: String) = {
     val li = doc.getElementById(elementId)
-    val divs = li.getElementsByTag("div")
-    divs.get(0).text mustBe messagesApi(messageKey)
-    divs.get(1).text mustBe ""
+    val dt = li.getElementsByTag("dt")
+    val dd = li.getElementsByTag("dd")
+    dt.get(0).text mustBe messagesApi(messageKey)
+    dd.get(0).text mustBe ""
 
     val link = li.getElementsByTag("a").get(0)
     messagesShouldBePresent(link.text, messagesApi(linkMessageKey))

--- a/test/iht/views/ihtHelpers/custom/GenericOverviewItemTest.scala
+++ b/test/iht/views/ihtHelpers/custom/GenericOverviewItemTest.scala
@@ -85,7 +85,7 @@ class GenericOverviewItemTest extends FakeIhtApp with HtmlSpec {
 
       val doc = asDocument(view)
       assertRenderedById(doc, s"$id-status")
-      assertEqualsValue(doc, s"div#$id-status span span:first-child", "Complete")
+      assertEqualsValue(doc, s"dd#$id-status span span:first-child", "Complete")
     }
 
   }

--- a/test/iht/views/registration/RegistrationSummaryViewTest.scala
+++ b/test/iht/views/registration/RegistrationSummaryViewTest.scala
@@ -289,13 +289,13 @@ class RegistrationSummaryViewTest extends ViewTestHelper {
     }
 
     "display the correct values in the table of entered details where all UK addresses" in {
-      val tableHTMLElements: Elements = doc.select("li.tabular-data__entry")
+      val tableHTMLElements: Elements = doc.select("dl > div.tabular-data__entry")
       val setRows = tableHTMLElements.map(element => SharableOverviewRow.apply(element)).toSet
       setRows mustBe expectedSetRowsAllUKAddresses
     }
 
     "display the correct values in the table of entered details where all foreign addresses" in {
-      val tableHTMLElements: Elements = docForeign.select("li.tabular-data__entry")
+      val tableHTMLElements: Elements = docForeign.select("dl > div.tabular-data__entry")
       val setRows = tableHTMLElements.map(element => SharableOverviewRow.apply(element)).toSet
       setRows mustBe expectedSetRowsAllForeignAddresses
     }
@@ -312,7 +312,7 @@ case class SharableOverviewRow(rowText: String = "", value: String = "", linkTex
 
 object SharableOverviewRow {
   def apply(element: Element): SharableOverviewRow = {
-    val cells = element.select("li > *:not(.visually-hidden)")
+    val cells = element.select("div > *:not(.visually-hidden)")
     val row = cells.size match {
       case 2 => SharableOverviewRow(
         rowText = cells.get(0).text,


### PR DESCRIPTION
Changed elements where most UL/LI are used to aide accessibility requirements throughout the service.
For example,
**UL/LI into table format that was more suited**

Before:
<img width="1260" alt="Screenshot 2022-02-14 at 10 33 07" src="https://user-images.githubusercontent.com/61423748/153848480-289a97de-7161-48b9-bbc6-9a146e0a2e6c.png">

After:
<img width="1359" alt="Screenshot 2022-02-14 at 10 24 59" src="https://user-images.githubusercontent.com/61423748/153848543-1fe7697a-5142-4978-8e92-49ac12e2a34f.png">


**UL/LI to definition list/summary list as on govuk design standards**

Before:
<img width="1239" alt="Screenshot 2022-02-14 at 10 30 30" src="https://user-images.githubusercontent.com/61423748/153848911-8c02b5d8-042a-4371-b554-eb488294fdc3.png">

After:
<img width="1151" alt="Screenshot 2022-02-14 at 10 22 30" src="https://user-images.githubusercontent.com/61423748/153849058-da47c578-4a0a-49f3-a1ee-73e2743c4b7f.png">

Unit tests have been updated to pass along with Acceptance tests(in another pr).
 